### PR TITLE
[APP-86] ToggleSwitch 컴포넌트 변경된 디자인에 따라 수정

### DIFF
--- a/src/components/toggleSwitch/ToggleSwitch.tsx
+++ b/src/components/toggleSwitch/ToggleSwitch.tsx
@@ -1,63 +1,69 @@
 import React, {useEffect} from 'react';
 import ToggleSwitchProps from './ToggleSwitch.type';
-import {Animated, StyleSheet, Pressable, Easing} from 'react-native';
+import {Animated, StyleSheet, Pressable, Easing, Platform, View} from 'react-native';
 import styled from '@emotion/native';
 
-const ToggleSwitch = ({isOn, size, onToggle}: ToggleSwitchProps) => {
+const ToggleSwitch = ({isOn, onToggle}: ToggleSwitchProps) => {
   useEffect(() => {
     Animated.timing(animatedValue, {
-      toValue: isOn ? 0 : 1,
+      toValue: isOn ? 1 : 0,
       duration: 200,
       easing: Easing.linear,
       useNativeDriver: true,
     }).start();
   }, [isOn]);
 
-  const animatedValue = new Animated.Value(isOn ? 1 : 0);
+  const animatedValue = new Animated.Value(isOn ? 0 : 1);
 
   const switchTranslateX = animatedValue.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, 14],
+    outputRange: [0, 15],
   });
 
   return (
-    <Wrap size={size}>
+    <Wrap>
       <Pressable onPress={onToggle}>
-        <ToggleContainer
-          style={{
+        <ToggleContainerWrapper style={styles.toggleContainer}>
+        <ToggleContainer style={{
             backgroundColor: isOn ? '#3A88F5' : '#B2B2B2',
-          }}>
+          }}>      
           <ToggleWheel
             style={[
               styles.toggleWheel,
               {transform: [{translateX: switchTranslateX}]},
             ]}
-          />
+          />  
         </ToggleContainer>
+        </ToggleContainerWrapper>
       </Pressable>
     </Wrap>
   );
 };
 
-const Wrap = styled.View<Pick<ToggleSwitchProps, 'size'>>`
-  transform: ${props => (props.size === 'small' ? 'scale(1)' : 'scale(1.4)')};
+const Wrap = styled.View`
   flex-direction: row;
   align-items: center;
 `;
 
 const ToggleContainer = styled.View`
-  width: 31px;
-  height: 16px;
-  padding-left: 2px;
-  border-radius: 15px;
+  width: 28px;
+  height: 12px;
+  border-radius: 35px;
   justify-content: center;
 `;
 
+const ToggleContainerWrapper=styled.View`
+width: 28px;
+height: 12px;
+border-radius: 35px;
+justify-content: center;
+`;
+
 const ToggleWheel = styled(Animated.View)`
-  width: 13px;
-  height: 13px;
+  width: 16px;
+  height: 16px;
   background-color: #ffffff;
-  border-radius: 12.5px;
+  border-radius: 23px;
 `;
 
 const styles = StyleSheet.create({
@@ -65,11 +71,27 @@ const styles = StyleSheet.create({
     shadowColor: '#000',
     shadowOffset: {
       width: 0,
-      height: 2,
+      height: 1,
     },
-    shadowOpacity: 0.2,
-    shadowRadius: 2.5,
-    elevation: 1.5,
+    shadowOpacity: 0.25,
+    shadowRadius: 3,
+    elevation: 1,
+  },
+  toggleContainer: {
+    width: 28,
+    height: 12,
+    borderRadius: 35,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: {width: 0, height: 1},
+        shadowOpacity: 0.25,
+        shadowRadius: 2,
+      },
+      android: {
+        elevation: 1,
+      },
+    }),
   },
 });
 

--- a/src/components/toggleSwitch/ToggleSwitch.type.ts
+++ b/src/components/toggleSwitch/ToggleSwitch.type.ts
@@ -1,6 +1,5 @@
 export type ToggleSwitchProps = {
-  isOn: boolean;
-  size: 'small' | 'medium';
+  isOn?: boolean;
   onToggle?: () => void;
 };
 


### PR DESCRIPTION
### Summary 

- ToggleSwitch 컴포넌트를 변경된 디자인에 따라 수정하였습니다.
- 컴포넌트 사용법은 이전 pr에서와 동일합니다. (이전 pr 코멘트 참고)

<img width="191" alt="image" src="https://github.com/uoslife/rebuild-client/assets/109050721/9df21f40-556a-4856-9096-6d3ddc4cfd68">


### 변경 사항
1. 통일된 크기로 수정되었기에, size prop을 삭제했습니다. 단일 크기의 ToggleSwitch만 사용 가능합니다.
2.  디자인을 변경했습니다. (toggleWheel 크기를 변경하고, 내부 그림자 효과를 추가하였습니다.)

### [props]
- isOn
- onToggle
