### PR TITLE
[APP-135] iOS 수출 규정 관련 문서 암호화 사용하지 않음으로 설정

### DIFF
--- a/ios/uoslife/Info.plist
+++ b/ios/uoslife/Info.plist
@@ -79,5 +79,7 @@
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
# Summary

<img width="667" alt="스크린샷 2023-09-27 오후 4 53 00" src="https://github.com/uoslife/rebuild-client/assets/76601773/f2006782-c127-45cf-a58b-80e8aa536798">
- 해당 설정(ITSAppUsesNonExemptEncryption)을 항상 false로 주어 iOS 내부 테스트시 설정을 일일히 해주지 않도록 하였습니다.
