### PR TITLE
[APP-195] 기존 유저의 닉네임 검증 방식 변경

### DIFF
--- a/src/screens/account/common/SetNicknameScreen.tsx
+++ b/src/screens/account/common/SetNicknameScreen.tsx
@@ -21,6 +21,8 @@ import useModal from '../../../hooks/useModal';
 import UserService from '../../../services/user';
 import useAccountFlow from '../../../hooks/useAccountFlow';
 
+const NICKNAME_MAX_LENGTH = 8;
+
 type NicknameStatusMessageType =
   | 'BEFORE_CHECK'
   | 'CAN_USE'
@@ -51,8 +53,18 @@ const SetNicknameScreen = () => {
   const [openModal, __, Modal] = useModal('MODAL');
 
   const handleSetNicknameButton = async () => {
-    // TODO: 사용 불가능 닉네임 로직 추가
-    // setStatusMessage('CANNOT_USE');
+    if (inputValue.length > NICKNAME_MAX_LENGTH) {
+      setStatusMessage('CANNOT_USE');
+      return;
+    }
+
+    if (
+      accountFlow.signUpFlow.signUpUser === 'MIGRATION' &&
+      selectedAccountInfo?.nickname === inputValue
+    ) {
+      openBottomSheet();
+      return;
+    }
 
     try {
       const CheckDuplicateUserNicknameRes =
@@ -186,7 +198,7 @@ const SetNicknameScreen = () => {
             </View>
             <Input
               onChangeText={onChangeText}
-              maxLength={8}
+              maxLength={NICKNAME_MAX_LENGTH}
               onPress={onPressInputDelete}
               value={inputValue}
               label="닉네임"


### PR DESCRIPTION
# Key Changes

- 기존 유저가 계정 통합 이후, migrationInfo의 닉네임인 경우 중복확인 API로 검증을 거치지 않도록 방식을 변경합니다.


# Closes Issue

close #172 