### PR TITLE
[APP-212] 공지사항 화면의 scroll Indicator가 가운데 나타나는 현상 해결

### DIFF
--- a/src/components/molecules/screens/announcement/article-list/ArticleList.tsx
+++ b/src/components/molecules/screens/announcement/article-list/ArticleList.tsx
@@ -18,6 +18,7 @@ const ArticleList = forwardRef<FlatList, ArticleListProps>(
     return (
       <FlatList
         ref={ref}
+        scrollIndicatorInsets={{right: 1}}
         contentContainerStyle={{flexGrow: 1, paddingBottom: 50}}
         renderItem={({item}) => (
           <ArticleItem

--- a/src/screens/announcement/AnnouncementDetailScreen.tsx
+++ b/src/screens/announcement/AnnouncementDetailScreen.tsx
@@ -57,7 +57,9 @@ const AnnouncementDetailScreen = ({
         <Spinner />
       ) : (
         article && (
-          <ScrollView contentContainerStyle={{paddingBottom: 100}}>
+          <ScrollView
+            contentContainerStyle={{paddingBottom: 100}}
+            scrollIndicatorInsets={{right: 1}}>
             <AnnouncementDetailScreenContent {...article} />
           </ScrollView>
         )


### PR DESCRIPTION
# Key Changes

- iOS: 공지사항 글 목록 조회화면, 상세화면에서 scroll Indicator가 가운데에 나타나는 현상을 해결합니다.

# Details

- ArticleList의 FlatList, AnnouncementDetailScreen의 ScrollView에 아래 속성을 추가했습니다.
```typescript
scrollIndicatorInsets={{ right: 1 }}
``` 

# Closes Issue

close #204 
