### PR TITLE
[APP-208] 전화번호 인증시 2번 회원탈퇴한 유저 대응

### DIFF
--- a/src/configs/toast/toastMessageProps.tsx
+++ b/src/configs/toast/toastMessageProps.tsx
@@ -1,4 +1,6 @@
+import {Linking} from 'react-native';
 import {ShowToastProps} from '.';
+import urls from '../urls';
 
 const toastMessage = {
   logout: '로그아웃에 성공했어요.',
@@ -11,6 +13,7 @@ const toastMessage = {
   changePhoneError: '전화번호를 변경하는 중 문제가 발생했어요.',
   portalAuthenticationSuccess: '포털 연동을 성공적으로 완료했어요.',
   notificationError: '알림 설정을 처리하는 중 문제가 발생했어요.',
+  unRegisterTwiceUserError: `회원탈퇴 이력이 2회 이상인 유저입니다.\n해당 팝업을 클릭하여 고객센터로 문의해주세요.`,
 };
 export type ToastMessageType = keyof typeof toastMessage;
 
@@ -49,6 +52,13 @@ const toastMessageProps: {[T in ToastMessageType]: ShowToastProps} = {
   notificationError: {
     type: 'error',
     title: toastMessage.notificationError,
+  },
+  unRegisterTwiceUserError: {
+    type: 'error',
+    title: toastMessage.unRegisterTwiceUserError,
+    onPress: () => {
+      Linking.openURL(urls.CONTACT_UOSLIFE);
+    },
   },
 };
 export default toastMessageProps;

--- a/src/configs/urls.ts
+++ b/src/configs/urls.ts
@@ -19,4 +19,6 @@ export default {
     ADVERTISING_AND_MARKETING_CONSENT: 'https://www.uoslife.team/notices/7',
   },
   KAKAOTALK_UOSLIFE: 'https://pf.kakao.com/_gMEHK',
+  CONTACT_UOSLIFE:
+    'https://even-maize-68a.notion.site/55eb7b449c9b461c8ba1c3a01a6209e1',
 };

--- a/src/screens/account/signIn/VerificationScreen.tsx
+++ b/src/screens/account/signIn/VerificationScreen.tsx
@@ -170,6 +170,11 @@ const VerificationScreen = () => {
       resetAccountFlow();
     } catch (err) {
       const error = err as SignInRes;
+      // @ts-ignore
+      if (error.code === 400) {
+        customShowToast('unRegisterTwiceUserError');
+        return;
+      }
 
       const {tempToken} = error.token;
       storeToken({tempToken});


### PR DESCRIPTION
# Key Changes

- 전화번호 인증시 회원탈퇴를 2번 한 유저에 대해 안내 문구로 대응합니다.

# Details

- 안내 toast 클릭 시 고객 문의 notion 페이지로 이동하도록 기능을 추가했습니다.


# Closes Issue

close #198 
