### PR TITLE
[APP-216] 회원가입 디자인 및 기능 수정 #213

### DIFF
--- a/src/components/molecules/screens/account/modalContents/ServiceAgreementOverlay.tsx
+++ b/src/components/molecules/screens/account/modalContents/ServiceAgreementOverlay.tsx
@@ -39,6 +39,10 @@ const ServiceAgreementOverlay = ({
     );
     return requiredStatus.every(obj => obj.checked);
   };
+  const isAllRequiredStatusChecked = () => {
+    const requiredStatus = overlayStatus.filter(obj => obj.type === 'REQUIRED');
+    return requiredStatus.every(obj => obj.checked);
+  };
 
   const handleClickCheckAllItem = () => {
     const firstItemCheckedStatus = getCheckedStatusById(0);
@@ -68,7 +72,7 @@ const ServiceAgreementOverlay = ({
   }, [getCheckedStatusById(1), getCheckedStatusById(2)]);
 
   return (
-    <S.Container style={{paddingBottom: insets.bottom}}>
+    <S.Container style={{paddingBottom: insets.bottom + 8}}>
       <BottomSheetCheckItem
         checked={getCheckedStatusById(0)}
         title="약관에 모두 동의"
@@ -95,7 +99,7 @@ const ServiceAgreementOverlay = ({
       <Button
         label="확인"
         isFullWidth
-        isEnabled={areAllStatusChecked()}
+        isEnabled={isAllRequiredStatusChecked()}
         onPress={() =>
           handleClickSubmitBottomSheetButton(getCheckedStatusById(3))
         }

--- a/src/screens/account/common/AccountIntegrationScreen.tsx
+++ b/src/screens/account/common/AccountIntegrationScreen.tsx
@@ -122,6 +122,7 @@ const S = {
     flex: 1;
   `,
   accountIntegrationContainer: styled.View`
+    flex: 1;
     padding: 28px 16px 0;
   `,
   idContainer: styled.ScrollView`
@@ -144,7 +145,7 @@ const S = {
     background-color: white;
     height: 64px;
     position: absolute;
-    bottom: 0;
+    bottom: -16px;
     left: 0;
     right: 0;
     width: 100%;

--- a/src/screens/account/common/SetNicknameScreen.tsx
+++ b/src/screens/account/common/SetNicknameScreen.tsx
@@ -22,6 +22,7 @@ import useAccountFlow from '../../../hooks/useAccountFlow';
 import customShowToast from '../../../configs/toast';
 import useUserState from '../../../hooks/useUserState';
 import useIsCurrentScreen from '../../../hooks/useIsCurrentScreen';
+import NotificationService from '../../../services/notification';
 
 const NICKNAME_MAX_LENGTH = 8;
 
@@ -99,6 +100,8 @@ const SetNicknameScreen = () => {
   const handleClickSubmitBottomSheetButton = async (
     isAdvertismentAgree: boolean,
   ) => {
+    const isAuthorized =
+      await NotificationService.checkPermissionIsAuthorizedStatus();
     setIsAdvertismentAgree(isAdvertismentAgree);
     if (selectedAccountInfo) delete selectedAccountInfo.isSelected;
     try {
@@ -107,7 +110,7 @@ const SetNicknameScreen = () => {
         tos: {
           privatePolicy: true,
           termsOfUse: true,
-          notification: false, // TODO: notification 동의 여부 받아오도록 수정
+          notification: isAuthorized,
           marketing: isAdvertismentAgree,
         },
         migrationUserInfo: selectedAccountInfo ?? null,


### PR DESCRIPTION
# Key Changes

- 계정 통합 화면에서 버튼 위치가 하단에서 띄워져 있는 부분을 수정했습니다.
- 닉네임 설정 화면의 BottomSheet에서 버튼 위치와 선택을 동의하지 않더라도 버튼이 활성화 되도록 수정했습니다.
- NotificationService의 checkPermissionIsAuthorizedStatus 메서드를 이용해 디바이스 알림 동의 정보도 같이 signUp API의 body에 보내도록 수정했습니다.

# Closes Issue

close #213 
