### PR TITLE
[APP-221] carousel 처음 컨텐츠로 돌아가는 동작 변경

### DIFF
--- a/src/components/molecules/common/carousel/Carousel.tsx
+++ b/src/components/molecules/common/carousel/Carousel.tsx
@@ -58,7 +58,7 @@ const Carousel = ({
       Math.floor(currentContentOffset / carouselWidth) + 1,
     );
     setIsMomentum(false);
-    if (Platform.OS === 'android') return;
+    if (!isMomentum) return;
     if (currentDisplayIndex === carouselDataLength) setIndex(0);
   };
 


### PR DESCRIPTION
# Key Changes

- Carousel의 onMomentumScrollEnd 함수 동작을 변경했습니다.

# Details

- Carousel의 FlatList가 momentum 상태, 즉 유저가 스크롤 중일 때는 마지막 컨텐츠에서 스크롤시 처음 컨텐츠로 가도록 합니다.
- 스크롤 중이 아닐 때는 해당 동작이 발생하지 않습니다.

# Closes Issue

close #224 