### PR TITLE
[APP-224] getFirebasePushToken 메서드 동작 변경

### DIFF
--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -71,7 +71,9 @@ export default class NotificationService {
   }
 
   static async getFirebasePushToken(): Promise<string> {
-    if (Platform.OS === 'ios') messaging().setAPNSToken('app');
+    if (Platform.OS === 'ios' && !storage.getBoolean('isNotFirstLoading')) {
+      messaging().setAPNSToken('app');
+    }
     const token = await this.getNotificationToken();
     return token;
   }


### PR DESCRIPTION
# Key Changes

- iOS 플랫폼일 때 APNs token을 설정하는 동작을 첫 구동시에만 실행되도록 변경합니다.

# Closes Issue

close #227 