### PR TITLE
[APP-227] 공지사항 > 알림설정 모달에서 공지사항 페이지가 보여지지 않는 문제

### DIFF
--- a/src/components/molecules/screens/announcement/modalContents/AlertSettingOverlay.tsx
+++ b/src/components/molecules/screens/announcement/modalContents/AlertSettingOverlay.tsx
@@ -7,6 +7,7 @@ import {Button, Txt} from '@uoslife/design-system';
 import {useNavigation} from '@react-navigation/native';
 import BottomSheetToggleItem from '../../../overlays/items/BottomSheetToggleItem';
 import useTopicState from '../../../../../hooks/useTopicState';
+import Skeleton from '../../../common/skeleton/Skeleton';
 
 const AlertSettingOverlay = () => {
   const insets = useSafeAreaInsets();
@@ -29,7 +30,11 @@ const AlertSettingOverlay = () => {
   return (
     <S.Container style={{paddingBottom: insets.bottom + 12}}>
       {isLoading ? (
-        <View style={{height: 340}} />
+        <View style={{height: 356, paddingTop: 28, gap: 28}}>
+          <Skeleton variant="text" />
+          <Skeleton variant="text" />
+          <Skeleton variant="text" />
+        </View>
       ) : (
         <>
           <S.Description>


### PR DESCRIPTION
# Key Changes

- 공지사항화면 > 알림설정 BottomSheet에서 '알림 설정으로 이동' 버튼을 눌렀을 때 넘어가지 않는 문제를 해결했습니다.

# Details

- 안내문구에서 'My Page' > '마이페이지'로 워딩을 수정했습니다.
- BottomSheet에서 로딩이 될 때 까지 Skeleton UI를 보여주도록 구현했습니다.

# Closes Issue

close #240 
