### PR TITLE
[APP-230] Android: NotificationChannelGroup doesn't exist 에러

### DIFF
--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -45,12 +45,12 @@ export default class NotificationService {
           id: 'notification',
           name: '알림',
         }),
-        notifee.createChannel({
-          id: 'ETC',
-          name: '알림',
-          groupId: 'notification',
-        }),
       ]);
+      await notifee.createChannel({
+        id: 'ETC',
+        name: '알림',
+        groupId: 'notification',
+      });
     }
     // eslint-disable-next-line consistent-return
     return messaging().requestPermission();


### PR DESCRIPTION
# Key Changes

- 앱 초기 로딩시 Android에서 발생하는 [NotificationChannelGroup doesn't exist 에러](https://uoslife.sentry.io/issues/4736573695/?environment=production&project=4506321643569152&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=6)를 해결합니다.


# Details

- requestNotificationPermissions메서드에서 createChannelGroup 실행 이후 createChannel을 실행하도록 로직을 변경했습니다.

# Closes Issue

close #245 