### PR TITLE
[APP-244] iOS: 앱 재접속시 firebase push token이 초기화되는 현상 수정 

### DIFF
--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -85,9 +85,9 @@ export default class NotificationService {
   }
 
   static async getFirebasePushToken(): Promise<string> {
-    if (Platform.OS === 'ios') {
-      messaging().setAPNSToken('app');
-    }
+    // if (Platform.OS === 'ios') {
+    //   messaging().setAPNSToken('app');
+    // }
     const token = await this.getNotificationToken();
     return token;
   }


### PR DESCRIPTION
# Key Changes

- iOS에서 앱 재접속시 firebase push token이 초기화되는 현상을 수정했습니다.

# Details

- getFirebasePushToken 메서드에서 APNs token을 심어주는 로직을 삭제했습니다.

# Closes Issue

close #272 
