### PR TITLE
[APP-245] Android: 배너 이미지가 겹쳐보이는 현상 수정

### DIFF
--- a/src/components/molecules/common/carousel/Carousel.tsx
+++ b/src/components/molecules/common/carousel/Carousel.tsx
@@ -158,7 +158,6 @@ const S = {
   CarouselWrapper: styled.FlatList`
     position: relative;
     border-radius: 20px;
-    overflow: hidden;
   `,
   CarouselImage: styled.Image`
     object-fit: fill;


### PR DESCRIPTION
# Key Changes

- Carousel 컴포넌트의 이미지가 겹쳐보이는 현상을 수정했습니다.

# Details

- Carousel의 FlatList 컴포넌트에 overflow: hidden 속성값을 삭제했습니다.

# Closes Issue

close #275 
