### PR TITLE
[APP-250] 전화번호 인증시 서버에서 요청 제한되는 경우 대응

### DIFF
--- a/src/screens/account/signIn/VerificationScreen.tsx
+++ b/src/screens/account/signIn/VerificationScreen.tsx
@@ -69,7 +69,7 @@ const VerificationScreen = () => {
       case 'NOT_MATCHING_CODE':
         return '입력하신 인증번호가 일치하지 않습니다.';
       case 'REQUEST_EXCEED':
-        return '1일 인증 요청 가능 횟수(5회)를 초과하였습니다.';
+        return '서버 요청 과부하로 인해 잠시후 다시 시도해주세요.';
       case 'TIME_EXPIRED':
         return '요청된 시간이 만료되었습니다.';
     }


### PR DESCRIPTION
# Key Changes

- 전화번호 인증이 서버에서 제한되는 경우, 기존 안내 문구가 유저에게 모호하게 받아들여질 수 있어 문구를 수정했습니다.

# Details

- 문구 변경
> 1일 인증 요청 가능 횟수(5회)를 초과하였습니다. 
> → 서버 요청 과부하로 인해 잠시후 다시 시도해주세요.

# Closes Issue

close #282 
