### PR TITLE
[APP-252] 사용자가 시스템 알림을 켰을 때 서버에 fcm token이 업데이트 되지 않는 문제

### DIFF
--- a/src/screens/myPage/MypageAppSettingScreen.tsx
+++ b/src/screens/myPage/MypageAppSettingScreen.tsx
@@ -8,6 +8,7 @@ import ToggleSwitch from '../../components/atoms/toggleSwitch/ToggleSwitch';
 import Header from '../../components/molecules/common/header/Header';
 import useTopicState from '../../hooks/useTopicState';
 import NotificationService from '../../services/notification';
+import DeviceService from '../../services/device';
 
 const MypageAppSettingScreen = () => {
   const insets = useSafeAreaInsets();
@@ -20,8 +21,8 @@ const MypageAppSettingScreen = () => {
         NotificationService.checkPermissionIsAuthorizedStatus(),
         NotificationService.handleFirebasePushToken(),
       ]);
-
       setIsAuthorized(isAuthorizedStatus);
+      if (isAuthorizedStatus) await DeviceService.updateDeviceInfo();
     })();
   }, []);
 


### PR DESCRIPTION
# Key Changes

- 서버에는 처음 회원가입 시 알림 수신 동의하지 않은 유저의 firebase push token 정보가 없습니다.
- 이 경우 사용자가 시스템에서 앱 알림을 켰을 때, 서버에서는 해당 유저의 token을 알지 못한다는 문제가 있습니다.
- 이에 알림 설정 화면에서 서버로 firebase push token을 보내는 동작을 구현했습니다.

# Details

- 알림 설정 화면에서 device의 알림이 켜진 경우 updateDeviceInfo를 실행하는 로직을 추가했습니다.

# Closes Issue

close #289 
