### PR TITLE
[APP-272] 기존 fetching 코드를 react query로 마이그레이션

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@react-navigation/stack": "^6.3.16",
     "@sentry/react-native": "^5.14.1",
     "@supabase/supabase-js": "^2.25.0",
+    "@tanstack/query-core": "^5.28.6",
     "@tanstack/react-query": "^5.17.9",
     "@uoslife/design-system": "^1.2.6",
     "@uoslife/react": "^1.1.4",
@@ -37,6 +38,7 @@
     "base-64": "^1.0.0",
     "jotai": "^2.3.1",
     "jotai-cache": "^0.3.0",
+    "jotai-tanstack-query": "^0.8.5",
     "ky": "^0.33.3",
     "react": "18.2.0",
     "react-native": "0.71.10",
@@ -63,6 +65,7 @@
     "react-native-url-polyfill": "^1.3.0",
     "react-native-webview": "^13.2.1",
     "utf8": "^3.0.0",
+    "wonka": "^6.3.4",
     "yarn": "^1.22.19"
   },
   "devDependencies": {

--- a/src/components/molecules/screens/library/LibraryUserInfo.tsx
+++ b/src/components/molecules/screens/library/LibraryUserInfo.tsx
@@ -1,4 +1,3 @@
-import {useEffect} from 'react';
 import styled from '@emotion/native';
 import {Txt} from '@uoslife/design-system';
 import {useAtom} from 'jotai';
@@ -8,7 +7,6 @@ import TextItems from '../../common/textItems/TextItems';
 
 import useUserState from '../../../../hooks/useUserState';
 
-import UtilityService from '../../../../services/utility';
 import {UserAtomType} from '../../../../store/account/user';
 import libraryReservationAtom, {
   ReservationStatusTypeInUsing,
@@ -26,66 +24,55 @@ const getInformationMessage = (
 
 const LibraryUserInfo = () => {
   const {user} = useUserState();
-  const [
-    {reservationStatus, reservationInfo, isStudyRoom},
-    setLibraryReservation,
-  ] = useAtom(libraryReservationAtom);
-
-  useEffect(() => {
-    (async () => {
-      const res = await UtilityService.getLibraryReservation();
-      setLibraryReservation(res);
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const [{data}] = useAtom(libraryReservationAtom);
 
   return (
     <S.userInfoWrapper>
-      {reservationInfo ? (
+      {data.reservationInfo ? (
         <Txt
           color="grey190"
           label={getInformationMessage(
-            reservationStatus as ReservationStatusTypeInUsing,
+            data.reservationStatus as ReservationStatusTypeInUsing,
             user,
           )}
           typograph="titleLarge"
         />
       ) : null}
       <LibraryCircleTimer
-        reservationStatus={reservationStatus}
-        remainingSeconds={reservationInfo?.remainingSeconds || null}
-        seatStartTime={reservationInfo?.seatStartTime || null}
+        reservationStatus={data.reservationStatus}
+        remainingSeconds={data.reservationInfo?.remainingSeconds || null}
+        seatStartTime={data.reservationInfo?.seatStartTime || null}
       />
-      {reservationInfo ? (
+      {data.reservationInfo ? (
         <S.InformationTextWrapper>
           <TextItems
             label="열람실"
             item={
-              isStudyRoom
-                ? reservationInfo.studyRoomName
-                : reservationInfo.seatRoomName
+              data.isStudyRoom
+                ? data.reservationInfo.studyRoomName
+                : data.reservationInfo.seatRoomName
             }
           />
           <TextItems
             label="좌석번호"
             item={`${
-              isStudyRoom
-                ? reservationInfo.studyRoomNo
-                : `${reservationInfo.seatNo}번`
+              data.isStudyRoom
+                ? data.reservationInfo.studyRoomNo
+                : `${data.reservationInfo.seatNo}번`
             }`}
           />
           <TextItems
             label="이용시간"
             item={
-              isStudyRoom
-                ? reservationInfo.studyRoomUseTime
-                : reservationInfo.seatUseTime
+              data.isStudyRoom
+                ? data.reservationInfo.studyRoomUseTime
+                : data.reservationInfo.seatUseTime
             }
           />
-          {!isStudyRoom && (
+          {!data.isStudyRoom && (
             <TextItems
               label="연장횟수"
-              item={`${reservationInfo.extendUsed}회 / ${reservationInfo.extendRemaining}회`}
+              item={`${data.reservationInfo.extendUsed}회 / ${data.reservationInfo.extendRemaining}회`}
             />
           )}
         </S.InformationTextWrapper>

--- a/src/components/molecules/screens/main/contents/CafeteriaContents.tsx
+++ b/src/components/molecules/screens/main/contents/CafeteriaContents.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/native';
-import {useAtom} from 'jotai';
 import {Txt, colors} from '@uoslife/design-system';
 
 import {useSuspenseQuery} from '@tanstack/react-query';
@@ -7,10 +6,8 @@ import {useFocusEffect} from '@react-navigation/core';
 import CardLayout from '../../../common/cardLayout/CardLayout';
 
 import {CafeteriaItemType} from '../../../../../api/services/util/cafeteria/cafeteriaAPI.type';
-import {mainScreenCafeteriaItemAtom} from '../../../../../store/cafeteria';
 import UtilityService from '../../../../../services/utility';
 import DateUtils from '../../../../../utils/date';
-import useRefreshOnFocus from '../../../../../hooks/useRefreshOnFocus';
 
 const CafeteriaBox = ({
   location,

--- a/src/components/molecules/screens/main/contents/LibraryContents.tsx
+++ b/src/components/molecules/screens/main/contents/LibraryContents.tsx
@@ -60,24 +60,14 @@ const LibraryContentsInNotUsing = () => {
 };
 
 const LibraryContents = () => {
-  const [{reservationInfo}, setLibraryReservation] = useAtom(
-    libraryReservationAtom,
-  );
-
-  useEffect(() => {
-    (async () => {
-      const res = await UtilityService.getLibraryReservation();
-      setLibraryReservation(res);
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const [{data}] = useAtom(libraryReservationAtom);
 
   return (
     <CardLayout>
-      {reservationInfo ? (
+      {data.reservationInfo ? (
         <LibraryContentsInUsing
-          seatRoomName={reservationInfo.seatRoomName}
-          seatNo={reservationInfo.seatNo}
+          seatRoomName={data.reservationInfo.seatRoomName}
+          seatNo={data.reservationInfo.seatNo}
         />
       ) : (
         <LibraryContentsInNotUsing />

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -109,7 +109,9 @@ const MainScreen = () => {
           label="도서관"
           iconName="library"
           iconColor="primaryDarker">
-          <LibraryContents />
+          <Suspense fallback={<Skeleton variant="card" />}>
+            <LibraryContents />
+          </Suspense>
         </MainServiceBox>
         <MainServiceBox
           label="공지사항"

--- a/src/screens/library/LibraryScreen.tsx
+++ b/src/screens/library/LibraryScreen.tsx
@@ -1,20 +1,30 @@
 import styled from '@emotion/native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {useNavigation} from '@react-navigation/native';
+import {useIsFocused, useNavigation} from '@react-navigation/native';
 
+import {useEffect} from 'react';
+import {useSetAtom} from 'jotai';
 import LibraryUserInfo from '../../components/molecules/screens/library/LibraryUserInfo';
 import LibrarySeatStatus from '../../components/molecules/screens/library/LibararySeatStatus';
 import Header from '../../components/molecules/common/header/Header';
 import LibraryUsageHistory from '../../components/molecules/screens/library/LibraryUsageHistory';
+import {isFocusedLibraryAtom} from '../../store/library';
 
 const LibraryScreen = () => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const isFocused = useIsFocused();
+  const setIsFocusedLibraryScreen = useSetAtom(isFocusedLibraryAtom);
 
   const handleGoBack = () => {
     navigation.goBack();
   };
+
+  // '이용 중인 좌석' API의 auto refetch를 위해 도서관 화면의 isFocused 상태를 저장합니다.
+  useEffect(() => {
+    setIsFocusedLibraryScreen(isFocused);
+  }, [isFocused, setIsFocusedLibraryScreen]);
 
   return (
     <ScrollView style={{paddingTop: insets.top}} bounces={false}>

--- a/src/store/library/index.ts
+++ b/src/store/library/index.ts
@@ -1,5 +1,7 @@
+import {atomWithSuspenseQuery} from 'jotai-tanstack-query';
 import {atom} from 'jotai';
 import {LibraryReservationType} from '../../api/services/util/library/libraryAPI.type';
+import UtilityService from '../../services/utility';
 
 export type ReservationStatusType =
   | 'USING'
@@ -19,14 +21,25 @@ export type LibraryReservationAtomType = {
   isStudyRoom: boolean | null;
 };
 
-const initLibraryReservationAtom: LibraryReservationAtomType = {
+// isFocusedLibraryAtom
+export const isFocusedLibraryAtom = atom<boolean>(false);
+const DEFAULT_GET_LIBRARY_RESERVATION_REFETCH_INTERVAL = 5 * 1000;
+
+// libraryReservationAtom
+const initialData: LibraryReservationAtomType = {
   reservationStatus: 'NOT_USING',
   reservationInfo: null,
   isStudyRoom: null,
 };
 
-const libraryReservationAtom = atom<LibraryReservationAtomType>(
-  initLibraryReservationAtom,
-);
+const libraryReservationAtom =
+  atomWithSuspenseQuery<LibraryReservationAtomType>(get => ({
+    queryKey: ['getLibraryReservation'],
+    queryFn: () => UtilityService.getLibraryReservation(),
+    initialData,
+    refetchInterval: get(isFocusedLibraryAtom)
+      ? DEFAULT_GET_LIBRARY_RESERVATION_REFETCH_INTERVAL
+      : false,
+  }));
 
 export default libraryReservationAtom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,6 +3578,11 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.17.9.tgz#1dac85c7c674bdfd132fe7cd5cb898921000bdcf"
   integrity sha512-8xcvpWIPaRMDNLMvG9ugcUJMgFK316ZsqkPPbsI+TMZsb10N9jk0B6XgPk4/kgWC2ziHyWR7n7wUhxmD0pChQw==
 
+"@tanstack/query-core@^5.28.6":
+  version "5.28.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.28.6.tgz#a3bdb108f9f8d4e2ba3163068dbe6ff55b905a81"
+  integrity sha512-hnhotV+DnQtvtR3jPvbQMPNMW4KEK0J4k7c609zJ8muiNknm+yoDyMHmxTWM5ZnlZpsz0zOxYFr+mzRJNHWJsA==
+
 "@tanstack/react-query@^5.17.9":
   version "5.17.9"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.17.9.tgz#74826465c1b2ecde17c6d2f1d03f10b611ac2363"
@@ -9326,6 +9331,11 @@ jotai-cache@^0.3.0:
   resolved "https://registry.yarnpkg.com/jotai-cache/-/jotai-cache-0.3.0.tgz#a7799b5e0b9c859d063276c5de54ab1b04cd30ca"
   integrity sha512-hV6DUD1frRpW0EN8Ss7n4KNaMZRBokQw6KPT3seA4P35QRXctMNUn4pHRlg3hzO+KBPpEZw+fyKlWAqagmuIwQ==
 
+jotai-tanstack-query@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/jotai-tanstack-query/-/jotai-tanstack-query-0.8.5.tgz#12616f18a7623cc3786f3e2d7b1e1b2dc60394b2"
+  integrity sha512-cFq+1sE7Qkt7Kh9Db2KE8LXdbPiGwCiy8S5YSEnjUDxF59A4XhoXTDJBuPiMIA1dD1/yMsNKr1ADfN5CvscYZw==
+
 jotai@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/jotai/-/jotai-2.3.1.tgz"
@@ -14025,6 +14035,11 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wonka@^6.3.4:
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.4.tgz#76eb9316e3d67d7febf4945202b5bdb2db534594"
+  integrity sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
## Key Changes
- 기존 API fetching 코드를 react query로 마이그레이션 합니다.

## Details
- getLibraryReservation API 호출을 jotai-tanstack-query를 이용하도록 변경했습니다.
- 도서관 화면이 Focus 될 경우 auto refetch되도록, isFocusedLibraryAtom로 focused 상태를 관리합니다. 
    - refetchInterval 시간은 5초입니다.

## Allocated Issue
- close #322 