### PR TITLE
[RN-15] API 호출시 timeout 및 retry 시간 수정

### DIFF
--- a/src/configs/api.ts
+++ b/src/configs/api.ts
@@ -1,6 +1,6 @@
-export const DEFAULT_API_TIMEOUT = 10 * 1000;
+export const DEFAULT_API_TIMEOUT = 3 * 1000;
 export const DEFAULT_API_RETRY_LIMIT = 4;
-export const DEFAULT_API_RETRY_BACKOFFLIMIT = 3 * 1000;
+export const DEFAULT_API_RETRY_BACKOFFLIMIT = 1000;
 
 export const BASE_API_URL = 'https://api.uoslife.com';
 export const CDN_API_URL = 'https://cdn.uoslife.net';


### PR DESCRIPTION
# Changes
- ky apiClient의 defaultOptions을 수정했습니다. 변경 사항은 아래와 같습니다.
```typescript
DEFAULT_API_TIMEOUT // 10초 > 3초
DEFAULT_API_RETRY_BACKOFFLIMIT// 3초 > 1초
``` 

# Close Issue
close #366 