### PR TITLE
[RN-31] 도서관 정보 토스트 추가

### DIFF
--- a/src/components/molecules/overlays/layouts/InformationToast.tsx
+++ b/src/components/molecules/overlays/layouts/InformationToast.tsx
@@ -1,0 +1,53 @@
+import {Txt, colors, Icon} from '@uoslife/design-system';
+import styled from '@emotion/native';
+type UseToastParams = {
+  toastType: 'ERROR' | 'COMPLETE';
+  children?: React.ReactNode;
+};
+const InformationToast = ({toastType, children}: UseToastParams) => {
+  switch (toastType) {
+    case 'ERROR':
+      return (
+        <S.ToastContainer background={colors.red}>
+          <Icon name="clear" width={24} height={24} color="white" />
+          <Txt
+            label={children ? children.toString() : ''}
+            color="white"
+            typograph="labelMedium"
+          />
+        </S.ToastContainer>
+      );
+    case 'COMPLETE':
+      return (
+        <S.ToastContainer background={colors.secondaryBrand}>
+          <Icon name="checkCircle" width={24} height={24} color="grey190" />
+          <Txt
+            label={children ? children.toString() : ''}
+            color="grey190"
+            typograph="labelMedium"
+          />
+        </S.ToastContainer>
+      );
+  }
+};
+export default InformationToast;
+
+interface ToastContainerProps {
+  background: string;
+}
+
+const S = {
+  ToastContainer: styled.View<ToastContainerProps>`
+    width: auto;
+    flex-direction: row;
+    background: ${props => props.background};
+    border-radius: 40px;
+    gap: 8px;
+    padding: 4px 8px;
+    align-items: center;
+  `,
+  ImageContainer: styled.Image`
+    width: 24px;
+    height: 24px;
+  `,
+};

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,28 @@
+import {useState} from 'react';
+import {View} from 'react-native';
+import InformationToast from '../components/molecules/overlays/layouts/InformationToast';
+
+type ToastType = 'ERROR' | 'COMPLETE';
+type UseToastReturnValue = [() => void, () => React.JSX.Element];
+
+const useToast = (toastType: ToastType, text: string): UseToastReturnValue => {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = () => {
+    setIsOpen(true);
+    setTimeout(() => {
+      setIsOpen(false);
+    }, 2000);
+  };
+  const Toast = () => {
+    if (!isOpen) return <View />;
+    //확장성을 위한 분기 처리
+    switch (toastType) {
+      case 'ERROR':
+        return <InformationToast toastType="ERROR">{text}</InformationToast>;
+      case 'COMPLETE':
+        return <InformationToast toastType="COMPLETE">{text}</InformationToast>;
+    }
+  };
+  return [open, Toast];
+};
+export default useToast;


### PR DESCRIPTION
# Key Changes

-도서관 정보 토스트를 구현했습니다.

# Details

- useToast hooks의 open 함수를 호출하면 토스트 메시지가 2000ms 간 표시되도록 구현했습니다.

  <img width="384" alt="스크린샷 2024-04-16 오후 5 34 10" src="https://github.com/uoslife/uoslife-client/assets/81405795/26329b29-dd34-4c34-ac87-d348a46d03b5">
 

- 사용 예시
`
const [open, Toast] = useToast(
    'COMPLETE',
    '좌석 연장은 잔여 이용 시간이 3시간 이하일 때 가능해요!'
);
`




# To Reviewers

-uoslife-library에 errorLight 색상과 error_outline 로고가 없어 임시로 다른 색상과 로고를 대체해놨습니다. 추후에 변경하겠습니다.
-현재 Toast의 width가 부모 요소 크기에 맞춰 렌더링되는 상황입니다. 자식 요소에 맞춰 width 설정이 필요합니다.

