### PR TITLE
[RN-35] 도서관 안내 메시지 팝업 추가

### DIFF
--- a/src/components/molecules/common/GuidePopup.tsx
+++ b/src/components/molecules/common/GuidePopup.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/native';
+import {Txt, colors, Icon} from '@uoslife/design-system';
+import {TouchableOpacity} from 'react-native';
+type GuidePopupProps = {
+  children: React.ReactNode;
+  tail: 'LEFT' | 'CENTER' | 'RIGHT';
+  onPress: () => void;
+};
+const GuidePopup = ({children, tail, onPress}: GuidePopupProps) => {
+  return (
+    <GuidePopupContainer>
+      <GuidePopupBody>
+        <Txt
+          label={children ? children.toString() : ''}
+          color="grey190"
+          typograph="labelMedium"
+        />
+        <IconWrapper onPress={() => onPress()}>
+          <Icon color={'secondaryUi'} name={'clear'} width={24} height={24} />
+        </IconWrapper>
+      </GuidePopupBody>
+      <TriangleWrapper tail={tail}>
+        <Triangle />
+      </TriangleWrapper>
+    </GuidePopupContainer>
+  );
+};
+export default GuidePopup;
+
+const GuidePopupContainer = styled.View`
+  position: absolute;
+  bottom: 40px;
+`;
+
+const GuidePopupBody = styled.View`
+  flex-direction: row;
+  padding: 10px 8px 10px 16px;
+  border-radius: 30px;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: ${colors.secondaryBrand};
+`;
+
+type TailProps = {tail: 'LEFT' | 'CENTER' | 'RIGHT'};
+const TriangleWrapper = styled.View<TailProps>`
+  ${props =>
+    props.tail === 'LEFT'
+      ? 'align-items: flex-start; left:5%;'
+      : props.tail === 'RIGHT'
+      ? 'align-items: flex-end; right:8px;'
+      : 'align-items: center;'}
+  width: 100%;
+`;
+
+const Triangle = styled.View`
+  border-style: solid;
+  border-color: ${colors.secondaryBrand} transparent transparent transparent;
+  border-width: 24px 12px 0 12px;
+  height: 0;
+  width: 0;
+  top: -10px;
+`;
+type IconWrapperProps = {onPress: () => void};
+const IconWrapper = styled(TouchableOpacity)<IconWrapperProps>``;

--- a/src/components/molecules/common/GuidePopup.tsx
+++ b/src/components/molecules/common/GuidePopup.tsx
@@ -42,9 +42,9 @@ type TailProps = {tail: 'LEFT' | 'CENTER' | 'RIGHT'};
 const TriangleWrapper = styled.View<TailProps>`
   ${props =>
     props.tail === 'LEFT'
-      ? 'align-items: flex-start; left:5%;'
+      ? 'align-items: flex-start; left:8px;'
       : props.tail === 'RIGHT'
-      ? 'align-items: flex-end; right:5%;'
+      ? 'align-items: flex-end; right:8px;'
       : 'align-items: center;'}
   width: 100%;
 `;

--- a/src/components/molecules/common/GuidePopup.tsx
+++ b/src/components/molecules/common/GuidePopup.tsx
@@ -2,19 +2,15 @@ import styled from '@emotion/native';
 import {Txt, colors, Icon} from '@uoslife/design-system';
 import {TouchableOpacity} from 'react-native';
 type GuidePopupProps = {
-  children: React.ReactNode;
+  label: string;
   tail: 'LEFT' | 'CENTER' | 'RIGHT';
   onPress: () => void;
 };
-const GuidePopup = ({children, tail, onPress}: GuidePopupProps) => {
+const GuidePopup = ({label, tail, onPress}: GuidePopupProps) => {
   return (
     <GuidePopupContainer>
       <GuidePopupBody>
-        <Txt
-          label={children ? children.toString() : ''}
-          color="grey190"
-          typograph="labelMedium"
-        />
+        <Txt label={label} color="grey190" typograph="labelMedium" />
         <IconWrapper onPress={() => onPress()}>
           <Icon color={'secondaryUi'} name={'clear'} width={24} height={24} />
         </IconWrapper>

--- a/src/components/molecules/common/GuidePopup.tsx
+++ b/src/components/molecules/common/GuidePopup.tsx
@@ -44,7 +44,7 @@ const TriangleWrapper = styled.View<TailProps>`
     props.tail === 'LEFT'
       ? 'align-items: flex-start; left:5%;'
       : props.tail === 'RIGHT'
-      ? 'align-items: flex-end; right:8px;'
+      ? 'align-items: flex-end; right:5%;'
       : 'align-items: center;'}
   width: 100%;
 `;

--- a/src/components/molecules/common/GuidePopup.tsx
+++ b/src/components/molecules/common/GuidePopup.tsx
@@ -1,19 +1,18 @@
+import {PressableProps} from 'react-native';
 import styled from '@emotion/native';
 import {Txt, colors, Icon} from '@uoslife/design-system';
-import {TouchableOpacity} from 'react-native';
+
 type GuidePopupProps = {
   label: string;
   tail: 'LEFT' | 'CENTER' | 'RIGHT';
   onPress: () => void;
-};
-const GuidePopup = ({label, tail, onPress}: GuidePopupProps) => {
+} & PressableProps;
+const GuidePopup = ({label, tail, onPress, ...props}: GuidePopupProps) => {
   return (
-    <GuidePopupContainer>
+    <GuidePopupContainer onPress={() => onPress()} {...props}>
       <GuidePopupBody>
         <Txt label={label} color="grey190" typograph="labelMedium" />
-        <IconWrapper onPress={() => onPress()}>
-          <Icon color={'secondaryUi'} name={'clear'} width={24} height={24} />
-        </IconWrapper>
+        <Icon color="secondaryUi" name="clear" width={20} height={20} />
       </GuidePopupBody>
       <TriangleWrapper tail={tail}>
         <Triangle />
@@ -23,24 +22,26 @@ const GuidePopup = ({label, tail, onPress}: GuidePopupProps) => {
 };
 export default GuidePopup;
 
-const GuidePopupContainer = styled.View`
+const GuidePopupContainer = styled.Pressable`
   position: absolute;
   bottom: 40px;
 `;
 
 const GuidePopupBody = styled.View`
   flex-direction: row;
-  padding: 10px 8px 10px 16px;
+  padding: 8px 10px 8px 16px;
   border-radius: 30px;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 6px;
   background: ${colors.secondaryBrand};
 `;
 
 type TailProps = {tail: 'LEFT' | 'CENTER' | 'RIGHT'};
+
 const TriangleWrapper = styled.View<TailProps>`
   ${props =>
+    // eslint-disable-next-line no-nested-ternary
     props.tail === 'LEFT'
       ? 'align-items: flex-start; left:8px;'
       : props.tail === 'RIGHT'
@@ -57,5 +58,3 @@ const Triangle = styled.View`
   width: 0;
   top: -10px;
 `;
-type IconWrapperProps = {onPress: () => void};
-const IconWrapper = styled(TouchableOpacity)<IconWrapperProps>``;

--- a/src/screens/library/main_screen/MySeatScreen.tsx
+++ b/src/screens/library/main_screen/MySeatScreen.tsx
@@ -1,10 +1,13 @@
 import {useAtom} from 'jotai';
 import styled from '@emotion/native';
-import {Button, Txt, colors} from '@uoslife/design-system';
+import {Button, Txt, colors, Icon} from '@uoslife/design-system';
+import {useState} from 'react';
+import {TouchableOpacity} from 'react-native';
 
 import libraryReservationAtom from '../../../store/library';
 import LibraryUserInfo from '../../../components/molecules/screens/library/LibraryUserInfo';
 import useModal from '../../../hooks/useModal';
+import GuidePopup from '../../../components/molecules/common/GuidePopup';
 
 type Props = {redirectSeatList: () => void};
 
@@ -12,18 +15,31 @@ const MySeatScreen = ({redirectSeatList}: Props) => {
   const [{data}] = useAtom(libraryReservationAtom);
   const [openExtendModal, closeExtendModal, ExtendModal] = useModal('MODAL');
   const [openReturnModal, closeReturnModal, ReturnModal] = useModal('MODAL');
-  
+  const [isGuidePopupOpen, setIsGuidePopupOpen] = useState(false);
+
   const handleOnPressExtend = () => {
     console.error('좌석 연장 api 연결하기');
   };
   const handleOnPressReturn = () => {
     console.error('좌석 반납 api 연결하기');
   };
-  
+  const close = () => {
+    setIsGuidePopupOpen(false);
+  };
   return (
     <>
       <S.Container>
         <LibraryUserInfo />
+        <S.InformationWrapper>
+          {isGuidePopupOpen && (
+            <GuidePopup tail="RIGHT" onPress={close}>
+              포털 계정 연동하면 좌석을 발권할 수 있어요!
+            </GuidePopup>
+          )}
+          <S.InformationButtonWrapper onPress={() => setIsGuidePopupOpen(true)}>
+            <Icon color={'grey190'} name={'clear'} width={24} height={24} />
+          </S.InformationButtonWrapper>
+        </S.InformationWrapper>
         {data.reservationInfo ? (
           <S.ButtonWrapper>
             <Button
@@ -32,8 +48,12 @@ const MySeatScreen = ({redirectSeatList}: Props) => {
               isRounded
               onPress={openExtendModal}
             />
-            <Button label="좌석 반납하기" isFullWidth isRounded onPress={openReturnModal}/>
-
+            <Button
+              label="좌석 반납하기"
+              isFullWidth
+              isRounded
+              onPress={openReturnModal}
+            />
           </S.ButtonWrapper>
         ) : (
           <S.ButtonWrapper>
@@ -107,7 +127,8 @@ export default MySeatScreen;
 const S = {
   Container: styled.View`
     padding: 0 16px;
-    gap: 24px;
+    gap: 12px;
+    margin-top: 12px;
   `,
   ButtonWrapper: styled.View`
     width: 100%;
@@ -121,5 +142,17 @@ const S = {
     width: 100%;
     height: 1px;
     background-color: ${colors.grey40};
+  `,
+  InformationWrapper: styled.View`
+    align-items: flex-end;
+    right: 20px;
+  `,
+  InformationButtonWrapper: styled(TouchableOpacity)`
+    width: 40px;
+    height: 40px;
+    background: ${colors.secondaryBrand};
+    border-radius: 100px;
+    justify-content: center;
+    align-items: center;
   `,
 };

--- a/src/screens/library/main_screen/MySeatScreen.tsx
+++ b/src/screens/library/main_screen/MySeatScreen.tsx
@@ -2,12 +2,13 @@ import {useAtom} from 'jotai';
 import styled from '@emotion/native';
 import {Button, Txt, colors, Icon} from '@uoslife/design-system';
 import {useState} from 'react';
-import {TouchableOpacity} from 'react-native';
 
 import libraryReservationAtom from '../../../store/library';
 import LibraryUserInfo from '../../../components/molecules/screens/library/LibraryUserInfo';
 import useModal from '../../../hooks/useModal';
 import GuidePopup from '../../../components/molecules/common/GuidePopup';
+import AnimatePress from '../../../components/animations/pressable_icon/AnimatePress';
+import boxShadowStyle from '../../../styles/boxShadow';
 
 type Props = {redirectSeatList: () => void};
 
@@ -33,13 +34,19 @@ const MySeatScreen = ({redirectSeatList}: Props) => {
         <S.InformationWrapper>
           {isGuidePopupOpen && (
             <GuidePopup
-              label="포털 계정 연동하면 좌석을 발권할 수 있어요!"
+              label="포털 계정을 연동하면 좌석을 발권할 수 있어요!"
               tail="RIGHT"
-              onPress={closeGuidePopup}></GuidePopup>
+              onPress={closeGuidePopup}
+              style={{...boxShadowStyle.bottomTapShadow}}
+            />
           )}
-          <S.IconWrapper onPress={() => setIsGuidePopupOpen(true)}>
-            <Icon color={'grey190'} name={'clear'} width={24} height={24} />
-          </S.IconWrapper>
+          <AnimatePress
+            variant="scale_up_3"
+            onPress={() => setIsGuidePopupOpen(prev => !prev)}>
+            <S.IconWrapper style={{...boxShadowStyle.bottomTapShadow}}>
+              <Icon color="grey190" name="clear" width={24} height={24} />
+            </S.IconWrapper>
+          </AnimatePress>
         </S.InformationWrapper>
         {data.reservationInfo ? (
           <S.ButtonWrapper>
@@ -148,7 +155,7 @@ const S = {
     align-items: flex-end;
     right: 20px;
   `,
-  IconWrapper: styled(TouchableOpacity)`
+  IconWrapper: styled.View`
     width: 40px;
     height: 40px;
     background: ${colors.secondaryBrand};

--- a/src/screens/library/main_screen/MySeatScreen.tsx
+++ b/src/screens/library/main_screen/MySeatScreen.tsx
@@ -37,9 +37,9 @@ const MySeatScreen = ({redirectSeatList}: Props) => {
               tail="RIGHT"
               onPress={closeGuidePopup}></GuidePopup>
           )}
-          <S.InformationButtonWrapper onPress={() => setIsGuidePopupOpen(true)}>
+          <S.IconWrapper onPress={() => setIsGuidePopupOpen(true)}>
             <Icon color={'grey190'} name={'clear'} width={24} height={24} />
-          </S.InformationButtonWrapper>
+          </S.IconWrapper>
         </S.InformationWrapper>
         {data.reservationInfo ? (
           <S.ButtonWrapper>
@@ -148,7 +148,7 @@ const S = {
     align-items: flex-end;
     right: 20px;
   `,
-  InformationButtonWrapper: styled(TouchableOpacity)`
+  IconWrapper: styled(TouchableOpacity)`
     width: 40px;
     height: 40px;
     background: ${colors.secondaryBrand};

--- a/src/screens/library/main_screen/MySeatScreen.tsx
+++ b/src/screens/library/main_screen/MySeatScreen.tsx
@@ -23,7 +23,7 @@ const MySeatScreen = ({redirectSeatList}: Props) => {
   const handleOnPressReturn = () => {
     console.error('좌석 반납 api 연결하기');
   };
-  const close = () => {
+  const closeGuidePopup = () => {
     setIsGuidePopupOpen(false);
   };
   return (
@@ -35,7 +35,7 @@ const MySeatScreen = ({redirectSeatList}: Props) => {
             <GuidePopup
               label="포털 계정 연동하면 좌석을 발권할 수 있어요!"
               tail="RIGHT"
-              onPress={close}></GuidePopup>
+              onPress={closeGuidePopup}></GuidePopup>
           )}
           <S.InformationButtonWrapper onPress={() => setIsGuidePopupOpen(true)}>
             <Icon color={'grey190'} name={'clear'} width={24} height={24} />

--- a/src/screens/library/main_screen/MySeatScreen.tsx
+++ b/src/screens/library/main_screen/MySeatScreen.tsx
@@ -32,9 +32,10 @@ const MySeatScreen = ({redirectSeatList}: Props) => {
         <LibraryUserInfo />
         <S.InformationWrapper>
           {isGuidePopupOpen && (
-            <GuidePopup tail="RIGHT" onPress={close}>
-              포털 계정 연동하면 좌석을 발권할 수 있어요!
-            </GuidePopup>
+            <GuidePopup
+              label="포털 계정 연동하면 좌석을 발권할 수 있어요!"
+              tail="RIGHT"
+              onPress={close}></GuidePopup>
           )}
           <S.InformationButtonWrapper onPress={() => setIsGuidePopupOpen(true)}>
             <Icon color={'grey190'} name={'clear'} width={24} height={24} />


### PR DESCRIPTION
# Key Changes

- 도서관 안내 메시지 팝업을 추가했습니다

# Details

- useModal을 이용하여 기존 modal과 동일하게 동작합니다. 
<img width="490" alt="스크린샷 2024-04-17 오전 12 12 13" src="https://github.com/uoslife/uoslife-client/assets/81405795/aced64fb-08c5-4abd-b3d0-4c794ce5ec8e">


# To Reviewers

- 추후에 시대생 라이브러리 로고 업로드 이후에 로고 수정하겠습니다.
- 기존에 있던 [RN-29]도서관 정보 모달과 [RN-31]도서관 정보 토스트 브랜치 삭제가 필요합니다.