### PR TITLE
[RN-42] 닉네임 변경시 하단 모달 뜨지 않도록 수정

### DIFF
--- a/src/screens/account/common/SetNicknameScreen.tsx
+++ b/src/screens/account/common/SetNicknameScreen.tsx
@@ -75,7 +75,7 @@ const SetNicknameScreen = () => {
       openBottomSheet();
       return;
     }
-    openBottomSheet();
+    if (!isMypage) openBottomSheet();
     try {
       const CheckDuplicateUserNicknameRes =
         await CoreAPI.checkDuplicateUserNickname({
@@ -99,7 +99,7 @@ const SetNicknameScreen = () => {
       }
       openBottomSheet();
     } catch (err) {
-      console.error(err);
+      customShowToast('changeNicknameError');
     }
   };
 


### PR DESCRIPTION
# Key Changes

- 닉네임 변경 페이지에서 '변경하기' 버튼 클릭시 하단 모달이 표시되지 않도록 수정했습니다.

# Closes Issue

close #412 
