### PR TITLE
[RN-40] '좌석 현황 보기' 버튼 클릭시 도서관 좌석 페이지로 이동

### DIFF
--- a/src/components/molecules/screens/main/contents/LibraryContents.tsx
+++ b/src/components/molecules/screens/main/contents/LibraryContents.tsx
@@ -50,7 +50,9 @@ const LibraryContentsInNotUsing = () => {
         size="medium"
         isFullWidth
         onPress={() => {
-          navigation.navigate('Library');
+          navigation.navigate('Library', {
+            screen: 'Library_room_status',
+          });
         }}
       />
     </S.NotUsingWrapper>

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -88,7 +88,7 @@ const MainScreen = () => {
             typograph="headlineSmall"
           />
         </View>
-        {/* <Carousel
+        <Carousel
           imageWidth={BANNER_WIDTH}
           imageHeight={BANNER_HEIGHT}
           carouselData={[
@@ -98,7 +98,7 @@ const MainScreen = () => {
           indicator="TOPRIGHT"
           logEventName="banner"
           autoPlayIntervalTime={MAIN_AUTOPLAY_INTERVAL_TIME}
-        /> */}
+        />
         <MainServiceBox
           label="오늘의 학식"
           iconName="cafeteria"
@@ -115,12 +115,12 @@ const MainScreen = () => {
             <LibraryContents />
           </Suspense>
         </MainServiceBox>
-        <MainServiceBox
+        {/* <MainServiceBox
           label="공지사항"
           iconName="campaign"
           iconColor="primaryDarker">
           <AnnounceContents />
-        </MainServiceBox>
+        </MainServiceBox> */}
       </S.MainWrapper>
     </S.MainContainer>
   );

--- a/src/screens/library/room_status/LibrarySeatingChartScreen.tsx
+++ b/src/screens/library/room_status/LibrarySeatingChartScreen.tsx
@@ -47,10 +47,11 @@ const LibrarySeatingChartScreen = ({
   };
   const handlePressReservation = () => {
     // @ts-ignore
-    navigation.navigate({
-      key: navigation.getParent()?.getState().routes[0].key ?? '',
-      params: {status: 'MY_SEAT'},
-    });
+    navigation.replace('Library', {params: {status: 'MY_SEAT'}});
+    // navigation.navigate({
+    //   key: navigation.getParent()?.getState().routes[0].key ?? '',
+    //   params: {status: 'MY_SEAT'},
+    // });
     setSelectedSeat(initSelectedSeatAtom);
   };
   return (


### PR DESCRIPTION
# Key Changes

- 메인페이지의 '좌석 현황 보기' 버튼 클릭시 도서관 좌석 페이지로 이동하도록 동작을 수정했습니다.

# Closes Issue

close #409 