### PR TITLE
[RN-45] 도서관 예약 API 연결

### DIFF
--- a/src/api/services/util/library/libraryAPI.interface.ts
+++ b/src/api/services/util/library/libraryAPI.interface.ts
@@ -22,4 +22,11 @@ export default interface LibraryService {
     Type.GetMyLibraryRankingParams,
     Type.GetMyLibraryRankingRes
   >;
+  getSeatList: ServiceFunc<Type.GetSeatListParams, Type.GetSeatListRes>;
+  reservationSeat: ServiceFunc<
+    Type.ReservationSeatParams,
+    Type.ReservationSeatRes
+  >;
+  extendSeat: ServiceFunc<Type.ExtendSeatParams, Type.ExtendSeatRes>;
+  returnSeat: ServiceFunc<Type.ReturnSeatParams, Type.ReturnSeatRes>;
 }

--- a/src/api/services/util/library/libraryAPI.ts
+++ b/src/api/services/util/library/libraryAPI.ts
@@ -1,4 +1,4 @@
-import {get} from '../../../core/methods';
+import {del, get, post} from '../../../core/methods';
 import LibraryService from './libraryAPI.interface';
 import * as Type from './libraryAPI.type';
 
@@ -21,5 +21,21 @@ const LibraryAPI: LibraryService = {
     get<Type.GetMyLibraryRankingRes>(
       `utility/libraries/leader-board/me?major=${params?.major}&duration=${params?.duration}`,
     ),
+  getSeatList: params =>
+    get<Type.GetSeatListRes>(
+      `utility/libraries/reservation/seat?room=${params?.room}`,
+    ),
+  reservationSeat: params =>
+    post<Type.GetMyLibraryRankingRes>(
+      `utility/libraries/reservation/seat`,
+      params,
+    ),
+  extendSeat: params =>
+    post<Type.ExtendSeatRes>(
+      `utility/libraries/reservation/seat/extend`,
+      params,
+    ),
+  returnSeat: params =>
+    del<Type.ReturnSeatRes>(`utility/libraries/reservation/seat`, params),
 };
 export default LibraryAPI;

--- a/src/api/services/util/library/libraryAPI.type.ts
+++ b/src/api/services/util/library/libraryAPI.type.ts
@@ -1,4 +1,5 @@
 import {LibraryRankingMajorType} from '../../../../configs/utility/libraryRanking/libraryRanking';
+import {SeatStatusType} from '../../../../configs/utility/librarySeatingChart/seatStatus';
 import {
   LibraryRankingTabsType,
   LibraryRoomStatusTabsType,
@@ -42,6 +43,7 @@ export type LibraryReservationType = {
   status: ReservationStatusTypeFromServer;
   seatRoomName: string;
   seatNo: string;
+  seatRoomNumber: string;
   seatUseTime: string;
   reservationMinutes: string;
   seatStartTime: string;
@@ -124,3 +126,30 @@ export type GetMyLibraryRankingRes = {
   nickname: string;
   totalRank: number;
 };
+
+export type GetSeatListParams = {
+  room: number;
+};
+
+export type GetSeatListRes = Array<{
+  seatNumber: number;
+  status: SeatStatusType;
+}>;
+
+export type ReservationSeatParams = {
+  roomId: number;
+  seatId: number;
+};
+export type ReservationSeatRes = {};
+
+export type ExtendSeatParams = {
+  roomId: number;
+  seatId: number;
+};
+export type ExtendSeatRes = {};
+
+export type ReturnSeatParams = {
+  roomId: number;
+  seatId: number;
+};
+export type ReturnSeatRes = {};

--- a/src/components/molecules/common/GuidePopup.tsx
+++ b/src/components/molecules/common/GuidePopup.tsx
@@ -34,7 +34,7 @@ const GuidePopupBody = styled.View`
   align-items: center;
   justify-content: center;
   gap: 6px;
-  background: ${colors.secondaryBrand};
+  background-color: ${colors.secondaryBrand};
 `;
 
 type TailProps = {tail: 'LEFT' | 'CENTER' | 'RIGHT'};

--- a/src/components/molecules/screens/library/LibrarySeatingChart.tsx
+++ b/src/components/molecules/screens/library/LibrarySeatingChart.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/native';
 import {memo, useMemo} from 'react';
 import {Dimensions, FlatList, View} from 'react-native';
+
 import {
   LIBRARY_ROW_COUNT,
   LIBRARY_SEATS,
@@ -11,15 +12,21 @@ import {
   findForDisabledPerson,
   findSeatStatusBySeatId,
 } from '../../../../utils/library/findSeatItem';
+import {GetSeatListRes} from '../../../../api/services/util/library/libraryAPI.type';
 
 const {width} = Dimensions.get('screen');
 
 type Props = {
   roomNumber: RoomNameType;
   handlePressItem: () => void;
+  seatList?: GetSeatListRes;
 };
 
-const LibrarySeatingChart = ({roomNumber, handlePressItem}: Props) => {
+const LibrarySeatingChart = ({
+  roomNumber,
+  handlePressItem,
+  seatList,
+}: Props) => {
   const itemWidth = useMemo(() => {
     const libraryRowCount = LIBRARY_ROW_COUNT.get(roomNumber);
     if (!libraryRowCount) return 0;
@@ -52,7 +59,7 @@ const LibrarySeatingChart = ({roomNumber, handlePressItem}: Props) => {
               scrollEnabled={false}
               data={rowItem}
               renderItem={({item}) => {
-                const status = findSeatStatusBySeatId(item);
+                const status = findSeatStatusBySeatId(seatList, item);
                 const forDisabledPerson = findForDisabledPerson(
                   roomNumber,
                   item,

--- a/src/components/molecules/screens/library/main/my_seat/LibraryCircleTimer.tsx
+++ b/src/components/molecules/screens/library/main/my_seat/LibraryCircleTimer.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {CountdownCircleTimer} from 'react-native-countdown-circle-timer';
 import {Txt} from '@uoslife/design-system';
-import {ReservationStatusType} from '../../../../store/library';
+import {ReservationStatusType} from '../../../../../../store/library';
 import LibraryCircleTimerContents from './LibraryCircleTimerContents';
 import {
   DEFAULT_TRAIL_COLOR,
   LibraryCircleTimerDefaultProps,
-} from '../../../../configs/utility/library';
+} from '../../../../../../configs/utility/library';
 
 type LibraryCustomCircleTimerProps = {
   reservationStatus: ReservationStatusType;

--- a/src/components/molecules/screens/library/main/my_seat/LibraryCircleTimerContents.tsx
+++ b/src/components/molecules/screens/library/main/my_seat/LibraryCircleTimerContents.tsx
@@ -6,8 +6,8 @@ import {
   CIRCLE_COLOR_MIN_TIME,
   CIRCLE_COLOR_NO_TIME,
   LIBRARY_NO_TIME,
-} from '../../../../configs/utility/library';
-import useLibraryDisplayTime from '../../../../hooks/useLibraryDisplayTime';
+} from '../../../../../../configs/utility/library';
+import useLibraryDisplayTime from '../../../../../../hooks/useLibraryDisplayTime';
 
 type Props = {
   isUsingStatus: boolean;

--- a/src/components/molecules/screens/library/main/my_seat/LibrarySeatControl.tsx
+++ b/src/components/molecules/screens/library/main/my_seat/LibrarySeatControl.tsx
@@ -1,0 +1,106 @@
+import {useState} from 'react';
+import {useAtom} from 'jotai';
+import styled from '@emotion/native';
+import {Button, Icon, colors} from '@uoslife/design-system';
+
+import {View} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import useUserState from '../../../../../../hooks/useUserState';
+import boxShadowStyle from '../../../../../../styles/boxShadow';
+import AnimatePress from '../../../../../animations/pressable_icon/AnimatePress';
+import GuidePopup from '../../../../common/GuidePopup';
+import libraryReservationAtom from '../../../../../../store/library';
+import {MySeatScreenProps} from '../../../../../../screens/library/main_screen/MySeatScreen';
+import {LibraryNavigationProp} from '../../../../../../navigators/types/library';
+
+const LibrarySeatControl = ({
+  redirectSeatList,
+  openExtendSheet,
+  openReturnSheet,
+}: MySeatScreenProps) => {
+  const {user} = useUserState();
+  const navigation = useNavigation<LibraryNavigationProp>();
+
+  const [isGuidePopupOpen, setIsGuidePopupOpen] = useState(false);
+  const closeGuidePopup = () => {
+    setIsGuidePopupOpen(false);
+  };
+  const [{data}] = useAtom(libraryReservationAtom);
+  return (
+    <View>
+      {!user?.isVerified && (
+        <View style={{gap: 12}}>
+          <S.InformationWrapper>
+            {isGuidePopupOpen && (
+              <GuidePopup
+                label="포털 계정을 연동하면 좌석을 발권할 수 있어요!"
+                tail="RIGHT"
+                onPress={closeGuidePopup}
+                style={{...boxShadowStyle.bottomTapShadow}}
+              />
+            )}
+            <AnimatePress
+              variant="scale_up_3"
+              onPress={() => setIsGuidePopupOpen(prev => !prev)}>
+              <S.IconWrapper style={{...boxShadowStyle.bottomTapShadow}}>
+                <Icon color="grey190" name="info" width={24} height={24} />
+              </S.IconWrapper>
+            </AnimatePress>
+          </S.InformationWrapper>
+          <Button
+            label="포털 계정 연동하기"
+            isFullWidth
+            isRounded
+            onPress={() => navigation.navigate('Library_portal_authentication')}
+          />
+        </View>
+      )}
+      {user?.isVerified && (
+        <View style={{marginTop: 32}}>
+          {data.reservationInfo ? (
+            <View>
+              <Button
+                label="좌석 연장하기"
+                isFullWidth
+                isRounded
+                onPress={openExtendSheet}
+              />
+              <Button
+                label="좌석 반납하기"
+                isFullWidth
+                isRounded
+                onPress={openReturnSheet}
+              />
+            </View>
+          ) : (
+            <View>
+              <Button
+                label="좌석 발권하기"
+                isFullWidth
+                isRounded
+                onPress={redirectSeatList}
+              />
+            </View>
+          )}
+        </View>
+      )}
+    </View>
+  );
+};
+
+export default LibrarySeatControl;
+
+const S = {
+  InformationWrapper: styled.View`
+    align-items: flex-end;
+    right: 20px;
+  `,
+  IconWrapper: styled.View`
+    width: 40px;
+    height: 40px;
+    background: ${colors.secondaryBrand};
+    border-radius: 100px;
+    justify-content: center;
+    align-items: center;
+  `,
+};

--- a/src/components/molecules/screens/library/main/my_seat/LibraryUserInfo.tsx
+++ b/src/components/molecules/screens/library/main/my_seat/LibraryUserInfo.tsx
@@ -3,15 +3,15 @@ import {Txt} from '@uoslife/design-system';
 import {useAtom} from 'jotai';
 
 import LibraryCircleTimer from './LibraryCircleTimer';
-import TextItems from '../../common/textItems/TextItems';
+import TextItems from '../../../../common/textItems/TextItems';
 
-import useUserState from '../../../../hooks/useUserState';
+import useUserState from '../../../../../../hooks/useUserState';
 
-import {UserAtomType} from '../../../../store/account/user';
+import {UserAtomType} from '../../../../../../store/account/user';
 import libraryReservationAtom, {
   ReservationStatusTypeInUsing,
-} from '../../../../store/library';
-import {libraryInformationMessage} from '../../../../configs/utility/library';
+} from '../../../../../../store/library';
+import {libraryInformationMessage} from '../../../../../../configs/utility/library';
 
 const getInformationMessage = (
   reservationStatus: ReservationStatusTypeInUsing,

--- a/src/components/molecules/screens/library/ranking/LibraryRanking.tsx
+++ b/src/components/molecules/screens/library/ranking/LibraryRanking.tsx
@@ -205,7 +205,7 @@ const LibraryRanking = ({duration}: Props) => {
                 typograph="titleLarge"
               />
               <Txt
-                label={`${myRankingData.data?.time}시간`}
+                label={changeHourFromMin(myRankingData.data?.time)}
                 color="primaryBrand"
                 typograph="titleLarge"
               />

--- a/src/configs/deepLinking.ts
+++ b/src/configs/deepLinking.ts
@@ -52,11 +52,11 @@ const deepLinksConfig = {
           screens: {
             Library_seat_status_main: 'library/seatStatus',
             Library_seating_chart: 'library/seatingChart',
-            Library_portal_authentication: 'library/portalAuthentication',
           },
         },
         Library_ranking: 'library/ranking',
         Library_challenge: 'library/challenge',
+        Library_portal_authentication: 'library/portalAuthentication',
       },
     },
     Cafeteria: 'cafeteria',

--- a/src/configs/toast/toastMessageProps.tsx
+++ b/src/configs/toast/toastMessageProps.tsx
@@ -21,6 +21,19 @@ const toastMessage = {
 
   // utils
   preparingLibraryReservationInfo: '해당 열람실은 서비스 준비 중이에요.',
+  libraryReservationExtendSuccess: '좌석이 연장되었어요.',
+  libraryReservationExtendError: '좌석 연장에 실패했어요.',
+  libraryReservationReturnSuccess: '좌석이 반납되었어요.',
+  libraryReservationReturnError: '좌석 반납에 실패했어요.',
+  libraryReservationL03Error: '이미 이용 중인 좌석이에요.',
+  libraryReservationL04Error: '좌석 미반납 3회로 좌석을 이용할 수 없어요.',
+  libraryReservationL05Error:
+    '좌석 연장은 잔여 이용 시간이 180분 이하일 때 가능해요.',
+  libraryReservationL06Error: '좌석 연장 횟수(3회)가 초과되었어요.',
+  libraryReservationL07Error: '도서관 게이트 통과 후 예약해주세요.',
+  libraryReservationL08Error: '이미 이용 중인 좌석이 있어요.',
+  libraryReservationUnknownError:
+    '도서관 예약 중 알 수 없는 오류가 발생했어요.',
 
   // etc
   cannotOpenUrlError: '오류로 인해 해당 url을 열 수 없어요.',
@@ -107,9 +120,50 @@ const toastMessageProps: {[T in ToastMessageType]: ShowToastProps} = {
   },
 
   // utils
-
   preparingLibraryReservationInfo: {
     title: toastMessage.preparingLibraryReservationInfo,
+  },
+  libraryReservationExtendSuccess: {
+    title: toastMessage.libraryReservationExtendSuccess,
+  },
+  libraryReservationExtendError: {
+    type: 'error',
+    title: toastMessage.libraryReservationExtendError,
+  },
+  libraryReservationReturnSuccess: {
+    title: toastMessage.libraryReservationReturnSuccess,
+  },
+  libraryReservationReturnError: {
+    type: 'error',
+    title: toastMessage.libraryReservationReturnError,
+  },
+  libraryReservationL03Error: {
+    type: 'error',
+    title: toastMessage.libraryReservationL03Error,
+  },
+  libraryReservationL04Error: {
+    type: 'error',
+    title: toastMessage.libraryReservationL04Error,
+  },
+  libraryReservationL05Error: {
+    type: 'error',
+    title: toastMessage.libraryReservationL05Error,
+  },
+  libraryReservationL06Error: {
+    type: 'error',
+    title: toastMessage.libraryReservationL06Error,
+  },
+  libraryReservationL07Error: {
+    type: 'error',
+    title: toastMessage.libraryReservationL07Error,
+  },
+  libraryReservationL08Error: {
+    type: 'error',
+    title: toastMessage.libraryReservationL08Error,
+  },
+  libraryReservationUnknownError: {
+    type: 'error',
+    title: toastMessage.libraryReservationUnknownError,
   },
 
   // etc

--- a/src/navigators/LibraryStackNavigator.tsx
+++ b/src/navigators/LibraryStackNavigator.tsx
@@ -29,10 +29,6 @@ const LibraryRoomStatusNavigator = () => {
         name="Library_seating_chart"
         component={LibrarySeatingChartScreen}
       />
-      <LibraryRoomStatusStack.Screen
-        name="Library_portal_authentication"
-        component={PortalAuthenticationScreen}
-      />
     </LibraryRoomStatusStack.Navigator>
   );
 };
@@ -51,6 +47,10 @@ const LibraryStackNavigator = () => {
       <Stack.Screen
         name="Library_challenge"
         component={LibraryChallengeScreen}
+      />
+      <Stack.Screen
+        name="Library_portal_authentication"
+        component={PortalAuthenticationScreen}
       />
     </Stack.Navigator>
   );

--- a/src/navigators/types/library.ts
+++ b/src/navigators/types/library.ts
@@ -8,12 +8,12 @@ export type LibraryStackParamList = {
   Library_ranking: undefined;
   Library_room_status?: LibraryRoomStatusStackParamList;
   Library_challenge: undefined;
+  Library_portal_authentication: undefined;
 };
 
 export type LibraryRoomStatusStackParamList = {
   Library_room_status_main?: {roomType?: 'ECONOMY' | 'LAW' | 'CENTRAL'};
   Library_seating_chart: {roomNumber: string};
-  Library_portal_authentication: undefined;
 };
 
 // navigation props

--- a/src/screens/library/LibraryMainScreen.tsx
+++ b/src/screens/library/LibraryMainScreen.tsx
@@ -3,6 +3,9 @@ import {useSetAtom} from 'jotai';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 
+import {Text, View} from 'react-native';
+import {Button, colors} from '@uoslife/design-system';
+import styled from '@emotion/native';
 import Header from '../../components/molecules/common/header/Header';
 import {isFocusedLibraryAtom} from '../../store/library';
 import {LibraryMainScreenProps} from '../../navigators/types/library';
@@ -14,6 +17,9 @@ import {
 import MySeatScreen from './main_screen/MySeatScreen';
 import RecordScreen from './main_screen/RecordScreen';
 import SeatListScreen from './main_screen/SeatListScreen';
+
+import useLibraryExtend from './useLibraryExtend';
+import useLibraryReturn from './useLibraryReturn';
 
 const LibraryMainScreen = ({route: {params}}: LibraryMainScreenProps) => {
   const insets = useSafeAreaInsets();
@@ -48,8 +54,21 @@ const LibraryMainScreen = ({route: {params}}: LibraryMainScreenProps) => {
     setIsFocusedLibraryScreen(isFocused);
   }, [isFocused, setIsFocusedLibraryScreen]);
 
+  const {
+    openExtendSheet,
+    closeExtendSheet,
+    ExtendBottomSheet,
+    handleOnPressExtend,
+  } = useLibraryExtend();
+  const {
+    openReturnSheet,
+    closeReturnSheet,
+    ReturnBottomSheet,
+    handleOnPressReturn,
+  } = useLibraryReturn();
+
   return (
-    <>
+    <View style={{flex: 1, position: 'relative'}}>
       <Header
         label="도서관"
         onPressBackButton={handleGoBack}
@@ -59,7 +78,13 @@ const LibraryMainScreen = ({route: {params}}: LibraryMainScreenProps) => {
         <TabView.Screen
           tabKey="MY_SEAT"
           tabTitle={LibraryTabsEnum.MY_SEAT}
-          component={<MySeatScreen redirectSeatList={() => setIndex(1)} />}
+          component={
+            <MySeatScreen
+              redirectSeatList={() => setIndex(1)}
+              openExtendSheet={openExtendSheet}
+              openReturnSheet={openReturnSheet}
+            />
+          }
         />
         <TabView.Screen
           tabKey="SEAT_LIST"
@@ -72,8 +97,73 @@ const LibraryMainScreen = ({route: {params}}: LibraryMainScreenProps) => {
           component={<RecordScreen />}
         />
       </TabView>
-    </>
+      <ExtendBottomSheet>
+        <S.SheetContainer style={{paddingBottom: insets.bottom + 8}}>
+          <Text
+            style={{
+              fontFamily: 'Pretendard-SemiBold',
+              fontSize: 21,
+              paddingLeft: 8,
+              color: colors.grey190,
+            }}>
+            좌석을 연장할까요?
+          </Text>
+          <View style={{gap: 8}}>
+            <Button
+              label="연장하기"
+              isFullWidth
+              onPress={handleOnPressExtend}
+              isRounded
+            />
+            <Button
+              label="취소"
+              variant="outline"
+              isFullWidth
+              onPress={closeExtendSheet}
+              isRounded
+            />
+          </View>
+        </S.SheetContainer>
+      </ExtendBottomSheet>
+      <ReturnBottomSheet>
+        <S.SheetContainer style={{paddingBottom: insets.bottom + 8}}>
+          <Text
+            style={{
+              fontFamily: 'Pretendard-SemiBold',
+              fontSize: 21,
+              paddingLeft: 8,
+              color: colors.grey190,
+            }}>
+            좌석을 반납할까요?
+          </Text>
+          <View style={{gap: 8}}>
+            <Button
+              label="반납하기"
+              isFullWidth
+              onPress={handleOnPressReturn}
+              isRounded
+            />
+            <Button
+              label="취소"
+              variant="outline"
+              isFullWidth
+              onPress={closeReturnSheet}
+              isRounded
+            />
+          </View>
+        </S.SheetContainer>
+      </ReturnBottomSheet>
+    </View>
   );
 };
 
 export default LibraryMainScreen;
+
+const S = {
+  SheetContainer: styled.View`
+    width: 100%;
+    margin: 0 auto;
+    padding: 26px 20px;
+    gap: 42px;
+  `,
+};

--- a/src/screens/library/main_screen/MySeatScreen.tsx
+++ b/src/screens/library/main_screen/MySeatScreen.tsx
@@ -1,166 +1,45 @@
-import {useAtom} from 'jotai';
 import styled from '@emotion/native';
-import {Button, Txt, colors, Icon} from '@uoslife/design-system';
-import {useState} from 'react';
-
+import {RefreshControl} from 'react-native';
+import {useAtom} from 'jotai';
+import LibraryUserInfo from '../../../components/molecules/screens/library/main/my_seat/LibraryUserInfo';
+import LibrarySeatControl from '../../../components/molecules/screens/library/main/my_seat/LibrarySeatControl';
+import usePullToRefresh from '../../../hooks/usePullToRefresh';
 import libraryReservationAtom from '../../../store/library';
-import LibraryUserInfo from '../../../components/molecules/screens/library/LibraryUserInfo';
-import useModal from '../../../hooks/useModal';
-import GuidePopup from '../../../components/molecules/common/GuidePopup';
-import AnimatePress from '../../../components/animations/pressable_icon/AnimatePress';
-import boxShadowStyle from '../../../styles/boxShadow';
 
-type Props = {redirectSeatList: () => void};
+export type MySeatScreenProps = {
+  redirectSeatList: () => void;
+  openExtendSheet: () => void;
+  openReturnSheet: () => void;
+};
 
-const MySeatScreen = ({redirectSeatList}: Props) => {
-  const [{data}] = useAtom(libraryReservationAtom);
-  const [openExtendModal, closeExtendModal, ExtendModal] = useModal('MODAL');
-  const [openReturnModal, closeReturnModal, ReturnModal] = useModal('MODAL');
-  const [isGuidePopupOpen, setIsGuidePopupOpen] = useState(false);
-
-  const handleOnPressExtend = () => {
-    console.error('좌석 연장 api 연결하기');
-  };
-  const handleOnPressReturn = () => {
-    console.error('좌석 반납 api 연결하기');
-  };
-  const closeGuidePopup = () => {
-    setIsGuidePopupOpen(false);
-  };
+const MySeatScreen = ({
+  redirectSeatList,
+  openExtendSheet,
+  openReturnSheet,
+}: MySeatScreenProps) => {
+  const [{refetch}] = useAtom(libraryReservationAtom);
+  const {onRefresh, refreshing} = usePullToRefresh(() => refetch());
   return (
-    <>
-      <S.Container>
-        <LibraryUserInfo />
-        <S.InformationWrapper>
-          {isGuidePopupOpen && (
-            <GuidePopup
-              label="포털 계정을 연동하면 좌석을 발권할 수 있어요!"
-              tail="RIGHT"
-              onPress={closeGuidePopup}
-              style={{...boxShadowStyle.bottomTapShadow}}
-            />
-          )}
-          <AnimatePress
-            variant="scale_up_3"
-            onPress={() => setIsGuidePopupOpen(prev => !prev)}>
-            <S.IconWrapper style={{...boxShadowStyle.bottomTapShadow}}>
-              <Icon color="grey190" name="info" width={24} height={24} />
-            </S.IconWrapper>
-          </AnimatePress>
-        </S.InformationWrapper>
-        {data.reservationInfo ? (
-          <S.ButtonWrapper>
-            <Button
-              label="좌석 연장하기"
-              isFullWidth
-              isRounded
-              onPress={openExtendModal}
-            />
-            <Button
-              label="좌석 반납하기"
-              isFullWidth
-              isRounded
-              onPress={openReturnModal}
-            />
-          </S.ButtonWrapper>
-        ) : (
-          <S.ButtonWrapper>
-            <Button
-              label="좌석 발권하기"
-              isFullWidth
-              isRounded
-              onPress={redirectSeatList}
-            />
-          </S.ButtonWrapper>
-        )}
-      </S.Container>
-      <ExtendModal>
-        <S.ExtendModalWrapper>
-          <Txt
-            label="좌석을 연장하시겠습니까?"
-            color="grey190"
-            typograph="titleMedium"
-            style={{padding: 16, paddingTop: 24, textAlign: 'center'}}
-          />
-          <S.Devider />
-          <Button
-            label="연장하기"
-            size="medium"
-            variant="text"
-            isFullWidth
-            onPress={handleOnPressExtend}
-          />
-          <S.Devider />
-          <Button
-            label="닫기"
-            size="medium"
-            variant="text"
-            isFullWidth
-            onPress={closeExtendModal}
-          />
-        </S.ExtendModalWrapper>
-      </ExtendModal>
-      <ReturnModal>
-        <S.ReturnModalWrapper>
-          <Txt
-            label="좌석을 반납하시겠습니까?"
-            color="grey190"
-            typograph="titleMedium"
-            style={{padding: 16, paddingTop: 24, textAlign: 'center'}}
-          />
-          <S.Devider />
-          <Button
-            label="반납하기"
-            size="medium"
-            variant="text"
-            isFullWidth
-            onPress={handleOnPressReturn}
-          />
-          <S.Devider />
-          <Button
-            label="닫기"
-            size="medium"
-            variant="text"
-            isFullWidth
-            onPress={closeReturnModal}
-          />
-        </S.ReturnModalWrapper>
-      </ReturnModal>
-    </>
+    <S.Container
+      refreshControl={
+        <RefreshControl onRefresh={onRefresh} refreshing={refreshing} />
+      }>
+      <LibraryUserInfo />
+      <LibrarySeatControl
+        redirectSeatList={redirectSeatList}
+        openExtendSheet={openExtendSheet}
+        openReturnSheet={openReturnSheet}
+      />
+    </S.Container>
   );
 };
 
 export default MySeatScreen;
 
 const S = {
-  Container: styled.View`
+  Container: styled.ScrollView`
     padding: 0 16px;
     gap: 12px;
     margin-top: 12px;
-  `,
-  ButtonWrapper: styled.View`
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  `,
-  ExtendModalWrapper: styled.View``,
-  ReturnModalWrapper: styled.View``,
-  Devider: styled.View`
-    width: 100%;
-    height: 1px;
-    background-color: ${colors.grey40};
-  `,
-  InformationWrapper: styled.View`
-    align-items: flex-end;
-    right: 20px;
-  `,
-  IconWrapper: styled.View`
-    width: 40px;
-    height: 40px;
-    background: ${colors.secondaryBrand};
-    border-radius: 100px;
-    justify-content: center;
-    align-items: center;
   `,
 };

--- a/src/screens/library/useLibraryExtend.ts
+++ b/src/screens/library/useLibraryExtend.ts
@@ -1,0 +1,46 @@
+import {useMutation} from '@tanstack/react-query';
+import {useAtom} from 'jotai';
+import {UtilAPI} from '../../api/services';
+import {ErrorResponseType} from '../../api/services/type';
+import {ExtendSeatParams} from '../../api/services/util/library/libraryAPI.type';
+import customShowToast from '../../configs/toast';
+import useModal from '../../hooks/useModal';
+import libraryReservationAtom from '../../store/library';
+import showLibraryErrorCode from '../../utils/library/showLibraryErrorCode';
+
+const useLibraryExtend = () => {
+  const [{data, refetch}] = useAtom(libraryReservationAtom);
+  const [openExtendSheet, closeExtendSheet, ExtendBottomSheet] =
+    useModal('BOTTOM_SHEET');
+
+  const extendSeatMutation = useMutation({
+    mutationKey: ['reservationSeat'],
+    mutationFn: (params: ExtendSeatParams) => UtilAPI.extendSeat(params),
+    onError: (error: ErrorResponseType) => {
+      showLibraryErrorCode(error.code, 'extend');
+      closeExtendSheet();
+    },
+    onSuccess: () => {
+      customShowToast('libraryReservationExtendSuccess');
+      closeExtendSheet();
+      refetch();
+    },
+  });
+
+  const handleOnPressExtend = () => {
+    if (!data.reservationInfo) return;
+    extendSeatMutation.mutate({
+      roomId: parseInt(data.reservationInfo.seatRoomNumber),
+      seatId: parseInt(data.reservationInfo.seatNo),
+    });
+  };
+
+  return {
+    openExtendSheet,
+    closeExtendSheet,
+    ExtendBottomSheet,
+    handleOnPressExtend,
+  };
+};
+
+export default useLibraryExtend;

--- a/src/screens/library/useLibraryReturn.ts
+++ b/src/screens/library/useLibraryReturn.ts
@@ -1,0 +1,46 @@
+import {useMutation} from '@tanstack/react-query';
+import {useAtom} from 'jotai';
+import {UtilAPI} from '../../api/services';
+import {ErrorResponseType} from '../../api/services/type';
+import {ReturnSeatParams} from '../../api/services/util/library/libraryAPI.type';
+import customShowToast from '../../configs/toast';
+import useModal from '../../hooks/useModal';
+import libraryReservationAtom from '../../store/library';
+import showLibraryErrorCode from '../../utils/library/showLibraryErrorCode';
+
+const useLibraryReturn = () => {
+  const [{data, refetch}] = useAtom(libraryReservationAtom);
+  const [openReturnSheet, closeReturnSheet, ReturnBottomSheet] =
+    useModal('BOTTOM_SHEET');
+
+  const returnSeatMutation = useMutation({
+    mutationKey: ['reservationSeat'],
+    mutationFn: (params: ReturnSeatParams) => UtilAPI.returnSeat(params),
+    onError: (error: ErrorResponseType) => {
+      showLibraryErrorCode(error.code, 'return');
+      closeReturnSheet();
+    },
+    onSuccess: () => {
+      customShowToast('libraryReservationReturnSuccess');
+      closeReturnSheet();
+      refetch();
+    },
+  });
+
+  const handleOnPressReturn = () => {
+    if (!data.reservationInfo) return;
+    returnSeatMutation.mutate({
+      roomId: parseInt(data.reservationInfo.seatRoomNumber),
+      seatId: parseInt(data.reservationInfo.seatNo),
+    });
+  };
+
+  return {
+    openReturnSheet,
+    closeReturnSheet,
+    ReturnBottomSheet,
+    handleOnPressReturn,
+  };
+};
+
+export default useLibraryReturn;

--- a/src/utils/library/findSeatItem.ts
+++ b/src/utils/library/findSeatItem.ts
@@ -1,27 +1,15 @@
+import {GetSeatListRes} from '../../api/services/util/library/libraryAPI.type';
 import {
   ROOM_2_FOR_DISABLED_PERSON_LIST,
   ROOM_4_FOR_DISABLED_PERSON_LIST,
 } from '../../configs/utility/librarySeatingChart/forDisabledPersonList';
 import {RoomNameType} from '../../configs/utility/librarySeatingChart/roomName';
-import {SeatStatusType} from '../../configs/utility/librarySeatingChart/seatStatus';
 
-const mock: Array<{seatId: number; status: SeatStatusType}> = [
-  {
-    seatId: 12,
-    status: 'NOT_AVAILABLE',
-  },
-  {
-    seatId: 14,
-    status: 'RESERVED',
-  },
-  {
-    seatId: 23,
-    status: 'SPECIFIED',
-  },
-];
-
-export const findSeatStatusBySeatId = (seatId: number) => {
-  return mock.find(item => item.seatId === seatId)?.status;
+export const findSeatStatusBySeatId = (
+  seatList: GetSeatListRes | undefined,
+  seatId: number,
+) => {
+  return seatList?.find(item => item.seatNumber === seatId)?.status;
 };
 
 export const findForDisabledPerson = (

--- a/src/utils/library/libraryRanking.ts
+++ b/src/utils/library/libraryRanking.ts
@@ -31,6 +31,7 @@ export const calculateRankingChartBgColor = (
   }
 };
 
-export const changeHourFromMin = (min: number) => {
+export const changeHourFromMin = (min: number | undefined) => {
+  if (!min) return '';
   return `${Math.floor(min / 60)}시간 ${min % 60}분`;
 };

--- a/src/utils/library/showLibraryErrorCode.ts
+++ b/src/utils/library/showLibraryErrorCode.ts
@@ -1,0 +1,26 @@
+import customShowToast from '../../configs/toast';
+
+const showLibraryErrorCode = (
+  code: string,
+  variant: 'reservation' | 'extend' | 'return',
+) => {
+  if (code === 'L03') customShowToast('libraryReservationL03Error');
+  else if (code === 'L04') customShowToast('libraryReservationL04Error');
+  else if (code === 'L05') customShowToast('libraryReservationL05Error');
+  else if (code === 'L06') customShowToast('libraryReservationL06Error');
+  else if (code === 'L07') customShowToast('libraryReservationL07Error');
+  else if (code === 'L08') customShowToast('libraryReservationL08Error');
+  else
+    switch (variant) {
+      case 'reservation':
+        customShowToast('libraryReservationUnknownError');
+        break;
+      case 'extend':
+        customShowToast('libraryReservationExtendError');
+        break;
+      case 'return':
+        customShowToast('libraryReservationReturnError');
+    }
+};
+
+export default showLibraryErrorCode;


### PR DESCRIPTION
# Key Changes

- 도서관 좌석 조회 및 예약, 반납 API를 추가 및 적용했습니다.

# Details

- 좌석 반납 및 연장 모달을 BottomSheet로 변경했습니다.
- 더불어 레이아웃이 tab screen 부모에 종속되는 문제가 있어 부득이하게 모달 컴포넌트를 최상단으로 옮기고, 관련 API를 hook으로 분리했습니다.
- 도서관 관련 에러 응답 코드를 에러 메세지와 함께 대응했습니다. 해당 에러 응답 코드는 [노션 링크](https://www.notion.so/6f9ce880b8ff4a318815a8450d33112c?pvs=4)에서 보실 수 있습니다.


# Closes Issue

close #420 
