### PR TITLE
[RN-16] Sentry의 sample rate 조절

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,11 @@ import AnimatedBootSplash from './screens/etc/AnimatedBootSplash';
 import toastConfig from './configs/toast/config';
 import CustomNavigationContainer from './screens/etc/CustomNavigationContainer';
 import bootSplashVisibleAtom from './store/app/bootSplashVisible';
+import {SENTRY_DEFAULT_SAMPLE_RATE} from './configs/sentry';
 
 Sentry.init({
   dsn: SENTRY_DSN_KEY,
+  sampleRate: SENTRY_DEFAULT_SAMPLE_RATE,
 });
 
 let App: React.FC = () => {

--- a/src/configs/sentry.ts
+++ b/src/configs/sentry.ts
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const SENTRY_DEFAULT_SAMPLE_RATE = 0.8;


### PR DESCRIPTION
# Key Changes

- Sentry의 sample rate를 0.8으로 조절했습니다.

# Closes Issue

close #368 
