### PR TITLE
[RN-52] 도서관 TF 배포 후 오류 수정

### DIFF
--- a/src/components/molecules/common/select/Select.tsx
+++ b/src/components/molecules/common/select/Select.tsx
@@ -1,7 +1,8 @@
-import styled from '@emotion/native';
+import styled, {css} from '@emotion/native';
 import {Txt, Icon, colors} from '@uoslife/design-system';
 import {useState} from 'react';
-import {ScrollView, View} from 'react-native';
+import {View} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
 import boxShadowStyle from '../../../../styles/boxShadow';
 import AnimatePress from '../../../animations/pressable_icon/AnimatePress';
 
@@ -33,7 +34,22 @@ const Select = ({options, currentOption, setCurrent}: SelectProps) => {
         </AnimatePress>
       </S.SelectContainer>
       {showOptions && (
-        <S.SelectOptions style={{...boxShadowStyle.LibraryShadow}}>
+        // https://github.com/facebook/react-native/issues/38730#issuecomment-1695742239
+        <ScrollView
+          style={[
+            {...boxShadowStyle.LibraryShadow},
+            css`
+              width: 200px;
+              height: 240px;
+              position: absolute;
+              top: 52px;
+              left: 50%;
+              transform: translateX(-100px);
+              border-radius: 20px;
+              background-color: white;
+              border: 0.7px solid ${colors.primaryLighterAlt};
+            `,
+          ]}>
           {options.map((item, index) => (
             <View key={item}>
               <S.SelectOptionsItems onPress={() => handlePressOption(item)}>
@@ -49,7 +65,7 @@ const Select = ({options, currentOption, setCurrent}: SelectProps) => {
               {options.length !== index - 1 && <S.SelectOptionsDivider />}
             </View>
           ))}
-        </S.SelectOptions>
+        </ScrollView>
       )}
     </>
   );
@@ -68,17 +84,6 @@ const S = {
     justify-content: space-between;
     gap: 4px;
     align-items: center;
-  `,
-  SelectOptions: styled.ScrollView`
-    width: 200px;
-    height: 240px;
-    position: absolute;
-    top: 52px;
-    left: 50%;
-    transform: translateX(-100px);
-    border-radius: 20px;
-    background-color: white;
-    border: 0.7px solid ${colors.primaryLighterAlt};
   `,
   SelectOptionsItems: styled.Pressable`
     padding: 10px 16px;

--- a/src/components/molecules/common/tab_view/TabView.tsx
+++ b/src/components/molecules/common/tab_view/TabView.tsx
@@ -30,9 +30,9 @@ const TabView = ({children, index, setIndex}: TabViewProps) => {
     return {key: tabKey, title: tabTitle, component};
   });
   const renderScene = SceneMap(transformSceneMap(routes));
-
   return (
     <RNTabView
+      lazy
       renderTabBar={props => (
         <TabBar
           {...props}

--- a/src/components/molecules/screens/library/LibraryChallengeBoard.tsx
+++ b/src/components/molecules/screens/library/LibraryChallengeBoard.tsx
@@ -4,11 +4,22 @@ import LibraryChallengeItem from './LibraryChallengeItem';
 import {ChallengeUserStatusType} from '../../../../configs/utility/libraryChallenge/challengeUserStatus';
 import boxShadowStyle from '../../../../styles/boxShadow';
 
-type Props = {status: ChallengeUserStatusType};
+type Props = {
+  status: {
+    max: ChallengeUserStatusType;
+    current: ChallengeUserStatusType;
+  };
+  setChallengeStatus: React.Dispatch<
+    React.SetStateAction<{
+      max: ChallengeUserStatusType;
+      current: ChallengeUserStatusType;
+    }>
+  >;
+};
 
-const LibraryChallengeBoard = ({status}: Props) => {
+const LibraryChallengeBoard = ({status, setChallengeStatus}: Props) => {
   const enabledItemsCount = (() => {
-    switch (status) {
+    switch (status.max) {
       case 'EGG':
         return 1;
       case 'BABY':
@@ -26,13 +37,17 @@ const LibraryChallengeBoard = ({status}: Props) => {
     }
   })();
 
-  const challengeItems = [
-    {label: '시작!', hours: 0},
-    {label: '10시간', hours: 10},
-    {label: '20시간', hours: 20},
-    {label: '30시간', hours: 30},
-    {label: '50시간', hours: 50},
-    {label: '100시간', hours: 100},
+  const challengeItems: Array<{
+    label: string;
+    hours: number;
+    userStatus: ChallengeUserStatusType;
+  }> = [
+    {label: '시작!', hours: 0, userStatus: 'EGG'},
+    {label: '10시간', hours: 10, userStatus: 'BABY'},
+    {label: '20시간', hours: 20, userStatus: 'CHICK'},
+    {label: '30시간', hours: 30, userStatus: 'JUNGDO'},
+    {label: '50시간', hours: 50, userStatus: 'CHEONJAE'},
+    {label: '100시간', hours: 100, userStatus: 'MANJAE'},
   ];
 
   return (
@@ -43,6 +58,12 @@ const LibraryChallengeBoard = ({status}: Props) => {
             key={item.label}
             label={item.label}
             isEnabled={index < enabledItemsCount}
+            isCurrent={item.userStatus === status.current}
+            onPress={() =>
+              setChallengeStatus(prev => {
+                return {...prev, current: item.userStatus};
+              })
+            }
           />
         ))}
       </S.Row>
@@ -52,6 +73,12 @@ const LibraryChallengeBoard = ({status}: Props) => {
             key={item.label}
             label={item.label}
             isEnabled={index + 3 < enabledItemsCount}
+            isCurrent={item.userStatus === status.current}
+            onPress={() =>
+              setChallengeStatus(prev => {
+                return {...prev, current: item.userStatus};
+              })
+            }
           />
         ))}
       </S.Row>

--- a/src/components/molecules/screens/library/LibraryChallengeItem.tsx
+++ b/src/components/molecules/screens/library/LibraryChallengeItem.tsx
@@ -1,31 +1,53 @@
 import styled from '@emotion/native';
 import {Txt, colors} from '@uoslife/design-system';
+import AnimatePress from '../../../animations/pressable_icon/AnimatePress';
 
 type Props = {
   label: string;
   isEnabled: boolean;
+  isCurrent: boolean;
+  onPress: () => void;
 };
 
-const LibraryChallengeItem = ({label, isEnabled}: Props) => {
+const changeBackgroundColor = ({
+  isEnabled,
+  isCurrent,
+}: Pick<Props, 'isEnabled' | 'isCurrent'>) => {
+  if (isCurrent) return colors.secondaryBrand;
+  if (isEnabled) return colors.secondaryLight;
+  return colors.grey10;
+};
+
+const LibraryChallengeItem = ({
+  label,
+  isEnabled,
+  isCurrent,
+  onPress,
+}: Props) => {
   return (
-    <S.Container isEnabled={isEnabled}>
-      <Txt
-        label={label}
-        color="black"
-        typograph={isEnabled ? 'titleSmall' : 'bodyMedium'}
-      />
-    </S.Container>
+    <AnimatePress
+      variant={isEnabled ? 'scale_up_3' : 'none'}
+      onPress={isEnabled ? onPress : () => {}}>
+      <S.Container
+        style={{
+          backgroundColor: changeBackgroundColor({isEnabled, isCurrent}),
+        }}>
+        <Txt
+          label={label}
+          color="black"
+          typograph={isEnabled ? 'titleSmall' : 'bodyMedium'}
+        />
+      </S.Container>
+    </AnimatePress>
   );
 };
 
 export default LibraryChallengeItem;
 
 const S = {
-  Container: styled.View<{isEnabled: boolean}>`
+  Container: styled.View`
     width: 80px;
     height: 80px;
-    background-color: ${({isEnabled}) =>
-      isEnabled ? colors.secondaryLight : colors.grey10};
     border-radius: 40px;
     display: flex;
     justify-content: center;

--- a/src/components/molecules/screens/library/main/my_seat/LibrarySeatControl.tsx
+++ b/src/components/molecules/screens/library/main/my_seat/LibrarySeatControl.tsx
@@ -58,7 +58,7 @@ const LibrarySeatControl = ({
       {user?.isVerified && (
         <View style={{marginTop: 32}}>
           {data.reservationInfo ? (
-            <View>
+            <View style={{gap: 12}}>
               <Button
                 label="좌석 연장하기"
                 isFullWidth

--- a/src/components/molecules/screens/library/ranking/LibraryRanking.tsx
+++ b/src/components/molecules/screens/library/ranking/LibraryRanking.tsx
@@ -25,9 +25,9 @@ import {
   LibraryRankingMajorNameType,
   LibraryRankingMajorName,
 } from '../../../../../configs/utility/libraryRanking/libraryRanking';
-import {UtilAPI} from '../../../../../api/services';
 import useUserState from '../../../../../hooks/useUserState';
 import Skeleton from '../../../common/skeleton/Skeleton';
+import UtilityService from '../../../../../services/utility';
 
 const TRIANGLE_WIDTH = Dimensions.get('screen').width - 96;
 const TRIANGLE_HEIGHT = TRIANGLE_WIDTH * (442 / 508);
@@ -96,7 +96,7 @@ const LibraryRanking = ({duration}: Props) => {
       {
         queryKey: ['getLibraryRanking', duration, major],
         queryFn: () =>
-          UtilAPI.getLibraryRanking({
+          UtilityService.getLibraryRanking({
             duration,
             major,
           }),
@@ -104,7 +104,7 @@ const LibraryRanking = ({duration}: Props) => {
       {
         queryKey: ['getMyLibraryRanking', duration, major],
         queryFn: () =>
-          UtilAPI.getMyLibraryRanking({
+          UtilityService.getMyLibraryRanking({
             duration,
             major,
           }),
@@ -137,7 +137,12 @@ const LibraryRanking = ({duration}: Props) => {
       refreshControl={
         <RefreshControl onRefresh={onRefresh} refreshing={refreshing} />
       }>
-      <S.SelectWrapper style={{zIndex: 10, elevation: 5}}>
+      <S.SelectWrapper
+        style={{
+          position: 'relative',
+          zIndex: 10,
+          elevation: 10,
+        }}>
         <Select
           options={LibraryRankingMajorName}
           currentOption={major}
@@ -226,6 +231,7 @@ export default LibraryRanking;
 const S = {
   Container: styled.ScrollView`
     padding: 0 14px;
+    position: relative;
   `,
   TopRankingBoxContainer: styled.View`
     flex-direction: row;

--- a/src/components/molecules/screens/main/contents/LibraryContents.tsx
+++ b/src/components/molecules/screens/main/contents/LibraryContents.tsx
@@ -1,5 +1,5 @@
 import {useAtom} from 'jotai';
-import {useNavigation} from '@react-navigation/native';
+import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import styled from '@emotion/native';
 import {Button, Icon, Txt, colors} from '@uoslife/design-system';
 import CardLayout from '../../../common/cardLayout/CardLayout';
@@ -60,8 +60,10 @@ const LibraryContentsInNotUsing = () => {
 };
 
 const LibraryContents = () => {
-  const [{data}] = useAtom(libraryReservationAtom);
-
+  const [{data, refetch}] = useAtom(libraryReservationAtom);
+  useFocusEffect(() => {
+    refetch();
+  });
   return (
     <CardLayout>
       {data.reservationInfo ? (

--- a/src/configs/utility/libraryRanking/libraryRanking.ts
+++ b/src/configs/utility/libraryRanking/libraryRanking.ts
@@ -6,6 +6,7 @@ export const LibraryRankingMajorName = [
   '건축학부',
   '경영학과',
   '경영학부',
+  '경제학부',
   '교류학과',
   '국사학과',
   '물리학과',

--- a/src/screens/library/LibraryMainScreen.tsx
+++ b/src/screens/library/LibraryMainScreen.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useMemo, useState} from 'react';
-import {useSetAtom} from 'jotai';
+import {useAtom, useSetAtom} from 'jotai';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 
@@ -7,7 +7,9 @@ import {Text, View} from 'react-native';
 import {Button, colors} from '@uoslife/design-system';
 import styled from '@emotion/native';
 import Header from '../../components/molecules/common/header/Header';
-import {isFocusedLibraryAtom} from '../../store/library';
+import libraryReservationAtom, {
+  isFocusedLibraryAtom,
+} from '../../store/library';
 import {LibraryMainScreenProps} from '../../navigators/types/library';
 import TabView from '../../components/molecules/common/tab_view/TabView';
 import {
@@ -48,11 +50,13 @@ const LibraryMainScreen = ({route: {params}}: LibraryMainScreenProps) => {
   const handleGoBack = () => {
     navigation.goBack();
   };
-
+  const [{refetch}] = useAtom(libraryReservationAtom);
   // '이용 중인 좌석' API의 auto refetch를 위해 도서관 화면의 isFocused 상태를 저장합니다.
   useEffect(() => {
-    setIsFocusedLibraryScreen(isFocused);
-  }, [isFocused, setIsFocusedLibraryScreen]);
+    const isFocusedMySeatScreen = isFocused && index === 0;
+    if (isFocusedMySeatScreen) refetch(); // 최초 진입시 한번 fetch 해오도록 구현
+    setIsFocusedLibraryScreen(isFocusedMySeatScreen);
+  }, [index, isFocused, refetch, setIsFocusedLibraryScreen]);
 
   const {
     openExtendSheet,

--- a/src/screens/library/main_screen/ChallengeScreen.tsx
+++ b/src/screens/library/main_screen/ChallengeScreen.tsx
@@ -10,13 +10,13 @@ import {
   ChallengeUserStatusEnum,
   ChallengeUserStatusType,
 } from '../../../configs/utility/libraryChallenge/challengeUserStatus';
-import {UtilAPI} from '../../../api/services';
 import usePullToRefresh from '../../../hooks/usePullToRefresh';
 import {changeHourFromMin} from '../../../utils/library/libraryRanking';
 import GuidePopup from '../../../components/molecules/common/GuidePopup';
 import boxShadowStyle from '../../../styles/boxShadow';
 import useUserState from '../../../hooks/useUserState';
 import customShowToast from '../../../configs/toast';
+import UtilityService from '../../../services/utility';
 
 export const ChallengUserStatusImgEnum: {
   [key in ChallengeUserStatusType]: any;
@@ -45,7 +45,7 @@ const ChallengeScreen = () => {
   const {data: challengeData, refetch} = useQuery({
     queryKey: ['getChallengeData', 'MONTH', '시대생'],
     queryFn: () =>
-      UtilAPI.getMyLibraryRanking({
+      UtilityService.getMyLibraryRanking({
         duration: 'MONTH',
         major: '시대생',
       }),
@@ -53,29 +53,32 @@ const ChallengeScreen = () => {
 
   const {refreshing, onRefresh} = usePullToRefresh(refetch);
 
-  const [challengeStatus, setChallengeStatus] =
-    useState<ChallengeUserStatusType>('EGG');
+  const [challengeStatus, setChallengeStatus] = useState<{
+    max: ChallengeUserStatusType;
+    current: ChallengeUserStatusType;
+  }>({max: 'EGG', current: 'EGG'});
 
   useEffect(() => {
     if (isGraduateUser) customShowToast('libraryChallengeGraduateUserInfo');
 
     if (challengeData?.time != null) {
       const timeInHours = challengeData.time / 60;
-      if (timeInHours < 10) setChallengeStatus('EGG');
+      if (timeInHours < 10) setChallengeStatus({max: 'EGG', current: 'EGG'});
       else if (timeInHours >= 10 && timeInHours < 20)
-        setChallengeStatus('BABY');
+        setChallengeStatus({max: 'BABY', current: 'BABY'});
       else if (timeInHours >= 20 && timeInHours < 30)
-        setChallengeStatus('CHICK');
+        setChallengeStatus({max: 'CHICK', current: 'CHICK'});
       else if (timeInHours >= 30 && timeInHours < 50)
-        setChallengeStatus('JUNGDO');
+        setChallengeStatus({max: 'JUNGDO', current: 'JUNGDO'});
       else if (timeInHours >= 50 && timeInHours < 100)
-        setChallengeStatus('CHEONJAE');
-      else if (timeInHours >= 100) setChallengeStatus('MANJAE');
+        setChallengeStatus({max: 'CHEONJAE', current: 'CHEONJAE'});
+      else if (timeInHours >= 100)
+        setChallengeStatus({max: 'MANJAE', current: 'MANJAE'});
     }
   }, [challengeData, isGraduateUser]);
 
   useEffect(() => {
-    if (challengeStatus === 'EGG') {
+    if (challengeStatus.max === 'EGG') {
       setIsGuidePopupOpen(true);
     }
   }, [challengeStatus]);
@@ -86,7 +89,9 @@ const ChallengeScreen = () => {
         <RefreshControl onRefresh={onRefresh} refreshing={refreshing} />
       }>
       <S.CharacterBox>
-        <S.ImageContainer source={ChallengUserStatusImgEnum[challengeStatus]} />
+        <S.ImageContainer
+          source={ChallengUserStatusImgEnum[challengeStatus.current]}
+        />
         {isGuidePopupOpen && (
           <GuidePopup
             label="도서관 누적 이용시간이 늘어날수록 루매가 성장해요."
@@ -101,7 +106,7 @@ const ChallengeScreen = () => {
         )}
         <S.TextBox>
           <Txt
-            label={ChallengeUserStatusEnum[challengeStatus]}
+            label={ChallengeUserStatusEnum[challengeStatus.current]}
             color="grey190"
             typograph="headlineMedium"
           />
@@ -112,7 +117,7 @@ const ChallengeScreen = () => {
               gap: 4px;
             `}>
             <Txt
-              label={ChallengeUserStatusDesEnum[challengeStatus]}
+              label={ChallengeUserStatusDesEnum[challengeStatus.current]}
               color="grey190"
               typograph="bodyMedium"
             />
@@ -133,7 +138,10 @@ const ChallengeScreen = () => {
         />
       </S.CardContainer>
 
-      <LibraryChallengeBoard status={challengeStatus} />
+      <LibraryChallengeBoard
+        status={challengeStatus}
+        setChallengeStatus={setChallengeStatus}
+      />
     </S.Container>
   );
 };

--- a/src/screens/library/room_status/LibrarySeatingChartScreen.tsx
+++ b/src/screens/library/room_status/LibrarySeatingChartScreen.tsx
@@ -185,7 +185,7 @@ const S = {
   SheetContainer: styled.View`
     width: 100%;
     margin: 0 auto;
-    padding: 24px 20px;
+    padding: 22px 20px;
     gap: 40px;
   `,
 };

--- a/src/screens/thirdTab/EventScreen.tsx
+++ b/src/screens/thirdTab/EventScreen.tsx
@@ -75,7 +75,7 @@ const EventScreen = () => {
                 style={{textAlign: 'center', fontSize: 44, lineHeight: 53}}
               />
               <Txt
-                label="4월 23일 - 31일"
+                label="4월 23일 - 30일"
                 color="grey190"
                 typograph="bodyLarge"
                 style={{textAlign: 'center'}}

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -86,9 +86,9 @@ export default class NotificationService {
   }
 
   static async getFirebasePushToken(): Promise<string> {
-    // if (Platform.OS === 'ios') {
-    //   messaging().setAPNSToken('app');
-    // }
+    if (Platform.OS === 'ios') {
+      messaging().setAPNSToken('app');
+    }
     const token = await this.getNotificationToken();
     return token;
   }

--- a/src/services/utility.ts
+++ b/src/services/utility.ts
@@ -6,7 +6,13 @@ import {
   GetCafeteriasResponse,
   MealTimeType,
 } from '../api/services/util/cafeteria/cafeteriaAPI.type';
-import {LibraryReservationType} from '../api/services/util/library/libraryAPI.type';
+import {
+  GetLibraryRankingRes,
+  GetMyLibraryRankingRes,
+  LibraryReservationType,
+} from '../api/services/util/library/libraryAPI.type';
+import {LibraryRankingMajorNameType} from '../configs/utility/libraryRanking/libraryRanking';
+import {LibraryRankingTabsType} from '../configs/utility/libraryTabs';
 import {
   DEFAULT_RESERVATION_STATUS,
   LibraryReservationAtomType,
@@ -132,6 +138,47 @@ export default class UtilityService {
       ]);
 
       return res[0];
+    } catch (error) {
+      return null;
+    }
+  }
+
+  static async getLibraryRanking({
+    duration,
+    major,
+  }: {
+    duration: LibraryRankingTabsType;
+    major: LibraryRankingMajorNameType;
+  }): Promise<GetLibraryRankingRes | null> {
+    try {
+      const res = await UtilAPI.getLibraryRanking({
+        duration,
+        major,
+      });
+      return res;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  static async getMyLibraryRanking({
+    duration,
+    major,
+  }: {
+    duration: LibraryRankingTabsType;
+    major: LibraryRankingMajorNameType;
+  }): Promise<GetMyLibraryRankingRes | null> {
+    try {
+      const res = await UtilAPI.getMyLibraryRanking({
+        duration,
+        major,
+      });
+      try {
+        CoreAPI.saveLibraryHistories({year: 2024});
+      } catch (err) {
+        console.error(err);
+      }
+      return res;
     } catch (error) {
       return null;
     }


### PR DESCRIPTION
# Key Changes

- 도서관 TF 배포 후 발생한 오류를 수정하고, 개선사항을 개선했습니다.

# Details

- 도서관 순위 > Select 토글이 [뒤에 뜨고](https://uoslifeteam.slack.com/archives/C06SXE98G4X/p1713872846037129), 스크롤 되지 않는 [현상](https://uoslifeteam.slack.com/archives/C06JYQS3Z4J/p1713869267635259)을 수정했습니다.
- Select 토글에 경제학부 옵션을 [추가](https://uoslifeteam.slack.com/archives/C06SXE98G4X/p1713869897298269)했습니다.
- 이벤트 페이지 이벤트 마감일을 31일 > 30일로 [수정](https://uoslifeteam.slack.com/archives/C06SXE98G4X/p1713894946006969)했습니다.
- 도서관 메인 > 내자리의 연장하기, 반납하기 버튼 간격을 [수정](https://uoslifeteam.slack.com/archives/C06SXE98G4X/p1713872092750939)했습니다.
- 도전과제 > 시간 버튼 클릭시 이전의 이미지와 상태도 확인 가능하도록 [기능을 추가](https://uoslifeteam.slack.com/archives/C06SXE98G4X/p1713871078245079) 했습니다.
이용중이지만, 이용중인 좌석이 표시되지 않는 현상을 [수정](https://uoslifeteam.slack.com/archives/C06JYQS3Z4J/p1713872541637399)했습니다.
- tabView에 lazy loading 옵션을 추가했습니다.

# Closes Issue

close #438 
