### PR TITLE
[RN-66] 메인페이지에서 도서관 API가 무한 refetch 하는 현상 #463

### DIFF
--- a/src/components/molecules/screens/main/contents/LibraryContents.tsx
+++ b/src/components/molecules/screens/main/contents/LibraryContents.tsx
@@ -1,7 +1,8 @@
 import {useAtom} from 'jotai';
-import {useFocusEffect, useNavigation} from '@react-navigation/native';
+import {useIsFocused, useNavigation} from '@react-navigation/native';
 import styled from '@emotion/native';
 import {Button, Icon, Txt, colors} from '@uoslife/design-system';
+import {useEffect} from 'react';
 import CardLayout from '../../../common/cardLayout/CardLayout';
 
 import {LibraryReservationType} from '../../../../../api/services/util/library/libraryAPI.type';
@@ -61,9 +62,10 @@ const LibraryContentsInNotUsing = () => {
 
 const LibraryContents = () => {
   const [{data, refetch}] = useAtom(libraryReservationAtom);
-  useFocusEffect(() => {
-    refetch();
-  });
+  const isFocused = useIsFocused();
+  useEffect(() => {
+    if (isFocused) refetch();
+  }, [isFocused, refetch]);
   return (
     <CardLayout>
       {data.reservationInfo ? (


### PR DESCRIPTION
# Key Changes

- 메인페이지의 도서관 reservation API 호출시 무한 refetch되는 현상을 수정했습니다.

# Details

- API 호출을 할때 `useFocusEffect` 대신, `useIsFocuesd` 훅을 이용해 구현했습니다.

# Closes Issue

close #463 
