### PR TITLE
[RN-67] 학생증 정보의 변수명 수정

### DIFF
--- a/src/screens/StudentIdScreen.tsx
+++ b/src/screens/StudentIdScreen.tsx
@@ -137,7 +137,7 @@ const StudentIdComponent = () => {
                     typograph="headlineMedium"
                   />
                   <Txt
-                    label={setUserInformationMessage(user?.studentId)}
+                    label={setUserInformationMessage(user?.identity.idNumber)}
                     color="grey190"
                     typograph="titleMedium"
                   />
@@ -154,7 +154,7 @@ const StudentIdComponent = () => {
                     typograph="bodyMedium"
                   />
                   <Txt
-                    label={setUserInformationMessage(user?.collegeName)}
+                    label={setUserInformationMessage(user?.identity.university)}
                     color="grey190"
                     typograph="bodyLarge"
                   />
@@ -167,7 +167,7 @@ const StudentIdComponent = () => {
                   />
 
                   <Txt
-                    label={setUserInformationMessage(user?.departmentName)}
+                    label={setUserInformationMessage(user?.identity.department)}
                     color="grey190"
                     typograph="bodyLarge"
                   />

--- a/src/screens/mypage/profile/MypageProfileScreen.tsx
+++ b/src/screens/mypage/profile/MypageProfileScreen.tsx
@@ -22,9 +22,19 @@ const getPortalAccountInfoList = (user: UserInfoType | null) => {
   if (!user?.identity) return [];
   return [
     {name: '이름', value: setUserInformationMessage(user.name)},
-    {name: '학과', value: setUserInformationMessage(user.identity.department)},
+    {
+      name: '학과',
+      value: `${setUserInformationMessage(
+        user.identity.university,
+      )} / ${setUserInformationMessage(user.identity.department)}`,
+    },
     {name: '학번', value: setUserInformationMessage(user.identity.idNumber)},
-    {name: '학적', value: setUserInformationMessage(user.identity.status)},
+    {
+      name: '학적',
+      value: `${setUserInformationMessage(
+        user.identity.type,
+      )} / ${setUserInformationMessage(user.identity.status)}`,
+    },
   ];
 };
 

--- a/src/screens/mypage/profile/PortalAuthenticationManagementScreen.tsx
+++ b/src/screens/mypage/profile/PortalAuthenticationManagementScreen.tsx
@@ -93,7 +93,7 @@ const PortalAuthenticationManagementScreen = () => {
                   onPress={() => setId(item.id)}
                   key={item.id}>
                   <Txt
-                    label={`${item.status}, ${item.idNumber}`}
+                    label={`${item.type} / ${item.status}, ${item.idNumber}`}
                     color="grey190"
                     typograph="titleMedium"
                   />


### PR DESCRIPTION
# Key Changes

- 학생증 정보 화면의 변수명을 마이그레이션된 account api 변수명에 대응했습니다.
- 포털 계정 정보에 identity.type, identity.university도 보여주도록 수정했습니다.

# Closes Issue

close #466 