### PR TITLE
[RN-70] 로그인 유지가 안되는 현상 수정

### DIFF
--- a/src/api/core/client.ts
+++ b/src/api/core/client.ts
@@ -41,6 +41,10 @@ export const accountApiClient = apiClient.extend({
   prefixUrl: ACCOUNT_API_URL,
 });
 
+export const accountApiClientForRefresh = baseApiClient.extend({
+  prefixUrl: ACCOUNT_API_URL,
+});
+
 export const cdnClient = apiClient.extend({
   prefixUrl: CDN_API_URL,
 });

--- a/src/api/services/account/auth/authAPI.ts
+++ b/src/api/services/account/auth/authAPI.ts
@@ -1,5 +1,5 @@
 import storage from '../../../../storage';
-import {accountApiClient} from '../../../core/client';
+import {accountApiClientForRefresh} from '../../../core/client';
 import {post} from '../../../core/methods';
 import AuthService from './authAPI.interface';
 import * as Type from './authAPI.type';
@@ -15,8 +15,7 @@ const AuthAPI: AuthService = {
     post<Type.VerifySMSAuthenticationRes>('v1/auth/verify', params, 'ACCOUNT'),
   getRefreshToken: async () => {
     const refreshToken = storage.getString('refreshToken');
-    const res = await accountApiClient.post('v1/auth/refresh', {
-      // TODO: 수정 필요 (무한 fetch)
+    const res = await accountApiClientForRefresh.post('v1/auth/refresh', {
       json: {refreshToken},
     });
     return await res.json();


### PR DESCRIPTION
# Key Changes

- 토큰 재발급 API의 base client를 변경하여 로그인 유지가 되지 않는 현상을 수정했습니다.

# Closes Issue

close #471 