### PR TITLE
[RN-78] 앱 초기 로딩시간 개선

### DIFF
--- a/ios/uoslife.xcodeproj/project.pbxproj
+++ b/ios/uoslife.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.beyondconnect.uoslife;
+				PRODUCT_BUNDLE_IDENTIFIER = com.beyondconnect.uoslife.alpha;
 				PRODUCT_NAME = uoslife;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -633,7 +633,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.beyondconnect.uoslife.DynamicIslandWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.beyondconnect.uoslife.alpha.DynamicIslandWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -762,10 +762,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				PRODUCT_NAME = "시대생 Debug";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -835,10 +832,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				PRODUCT_NAME = "시대생";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -910,10 +904,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				PRODUCT_NAME = "시대생 Alpha";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,4 +53,4 @@ const App: React.FC = () => {
 };
 
 // if (!__DEV__) App = codePush(App);
-export default Sentry.wrap(codePush(App));
+export default Sentry.wrap(App);

--- a/src/api/services/account/type/index.ts
+++ b/src/api/services/account/type/index.ts
@@ -1,7 +1,9 @@
 // auth
-export type AuthTokenDefaultRes = {
+export type JWTTokenType = {
   accessToken: string;
-  refreshToken: string;
+  refreshToken?: string;
+};
+export type AuthTokenDefaultRes = JWTTokenType & {
   reason:
     | 'logged_in' // 로그인 완료
     | 'registering' // 회원가입 필요

--- a/src/configs/app/update_guide.ts
+++ b/src/configs/app/update_guide.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+export const UPDATE_GUIDE = {
+  ALPHA_TITLE: '새로운 버전이 출시되었어요.(Alpha Environment)',
+  ALPHA_MESSAGE: 'App Distribution에서 앱을 최신버전으로 업데이트 해주세요.',
+  PROD_TITLE: '알림',
+  PROD_MESSAGE: `새로운 버전이 출시되었어요.\n 업데이트를 위해 앱 스토어로 이동합니다.`,
+};

--- a/src/hooks/useAppStateForeground.ts
+++ b/src/hooks/useAppStateForeground.ts
@@ -1,0 +1,24 @@
+import {useRef, useEffect} from 'react';
+import {AppState} from 'react-native';
+
+const useAppStateForeground = (callback: () => void) => {
+  const appState = useRef(AppState.currentState);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      if (
+        appState.current.match(/inactive|background/) &&
+        nextAppState === 'active'
+      ) {
+        callback();
+      }
+      appState.current = nextAppState;
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [callback]);
+};
+
+export default useAppStateForeground;

--- a/src/hooks/useInitApp.ts
+++ b/src/hooks/useInitApp.ts
@@ -1,5 +1,4 @@
-import {useState, useEffect, useMemo, useCallback} from 'react';
-import {Alert, Linking} from 'react-native';
+import {useEffect, useCallback} from 'react';
 import {useAtom, useSetAtom} from 'jotai';
 import CodePush, {
   DownloadProgress,
@@ -8,7 +7,6 @@ import CodePush, {
 } from 'react-native-code-push';
 
 import {captureException} from '@sentry/react-native';
-import DeviceService from '../services/device';
 import NotificationService from '../services/notification';
 import UserService from '../services/user';
 import storage from '../storage';
@@ -17,181 +15,125 @@ import bootSplashVisibleAtom from '../store/app/bootSplashVisible';
 import initLoadingAtom from '../store/app/initLoading';
 import syncProgressAtom from '../store/app/codepush';
 import customShowToast from '../configs/toast';
-import supabaseConfigAtom from '../store/app/supabaseConfig';
-import openAppstore from '../utils/app/openAppstore';
+import {SupabaseConfigAtomType} from '../store/app/supabaseConfig';
+import {guideUpdate} from '../utils/app/guideUpdate';
+import {handleFCMTokenBackground} from '../utils/app/handleFCMTokenBackground';
 
-const useInitApp = () => {
-  const [{data: configData}] = useAtom(supabaseConfigAtom);
-  const isMaintenance = useMemo(
-    () => configData?.config?.get('app.block') !== 'NO',
-    [configData],
-  );
+type Props = {
+  isFetching: boolean;
+  configData?: SupabaseConfigAtomType;
+};
 
-  const setAnimatedBootSplashVisible = useSetAtom(bootSplashVisibleAtom);
-  const setInitLoadingFinish = useSetAtom(initLoadingAtom);
+const useInitApp = ({configData, isFetching}: Props) => {
+  const setSplashScreenVisible = useSetAtom(bootSplashVisibleAtom);
+  const [isInitLoadingFinish, setInitLoadingFinish] = useAtom(initLoadingAtom);
 
-  const [isServiceInitLoading, setIsServiceInitLoading] = useState(true);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const {setUserInfo} = useUserState();
 
   // codepush
   const setSyncProgress = useSetAtom(syncProgressAtom);
-  const [codePushPackage, setCodePushPackage] = useState<RemotePackage>();
-
-  const checkForUpdateCodePush = useCallback(async () => {
-    const update = await CodePush.checkForUpdate();
-    if (!update) return;
-
-    setSyncProgress(prev => {
-      return {...prev, isUpdate: true};
-    });
-    setCodePushPackage(update);
-  }, [setSyncProgress]);
 
   const updateCodepush = useCallback(
-    async (update?: RemotePackage) => {
+    async (update: RemotePackage | null) => {
       if (!update) return;
-      try {
-        update
-          .download((progress: DownloadProgress) =>
-            setSyncProgress(prev => {
-              return {...prev, syncProgress: progress};
-            }),
-          )
-          .then((newPackage: LocalPackage) =>
-            newPackage.install(CodePush.InstallMode.IMMEDIATE).then(() => {
-              storage.set('isSuccessCodePushUpdate', true);
-              CodePush.notifyAppReady();
-              CodePush.restartApp();
-            }),
-          )
-          .finally(() =>
-            setSyncProgress(prev => {
-              return {...prev, isUpdate: false};
-            }),
-          );
-      } catch {
-        setSyncProgress(prev => {
-          return {...prev, isUpdate: false};
-        });
-      }
+      update
+        .download((progress: DownloadProgress) =>
+          setSyncProgress(prev => {
+            return {...prev, syncProgress: progress};
+          }),
+        )
+        .then((newPackage: LocalPackage) =>
+          newPackage.install(CodePush.InstallMode.IMMEDIATE).then(() => {
+            storage.set('isSuccessCodePushUpdate', true);
+            CodePush.notifyAppReady();
+            CodePush.restartApp();
+          }),
+        )
+        .catch(() => {
+          setSyncProgress(prev => {
+            return {...prev, isUpdate: false};
+          });
+        })
+        .finally(() =>
+          setSyncProgress(prev => {
+            return {...prev, isUpdate: false};
+          }),
+        );
     },
     [setSyncProgress],
   );
 
-  // loading
-  const setLoadingFinish = useCallback(() => {
-    if (!configData?.isLatestVersion) {
-      if (configData?.environment === 'alpha') {
-        Alert.alert(
-          '새로운 버전이 출시되었어요.(Alpha Environment)',
-          `iOS: testflight에서 앱을 업데이트 해주세요.\nAndroid: Playstore 내부 테스트에서 앱을 업데이트 해주세요.`,
-        );
-        return;
+  /** loading이 끝났을 때 동작 */
+  const handleLoadingFinish = async ({isLogin}: {isLogin?: boolean}) => {
+    if (isLogin) storage.set('isLoggedIn', true);
+
+    // codepush 업데이트 확인 후, 있으면 업데이트
+    try {
+      const codePushPackage = await CodePush.checkForUpdate();
+      if (codePushPackage) {
+        setSyncProgress(prev => {
+          return {...prev, isUpdate: true};
+        });
+        setSplashScreenVisible(true);
+        updateCodepush(codePushPackage);
       }
-      Alert.alert(
-        '알림',
-        `새로운 버전이 출시되었어요.\n 업데이트를 위해 앱 스토어로 이동합니다.`,
-        [
-          {
-            text: '이동하기',
-            onPress: openAppstore,
-          },
-        ],
-      );
+    } catch (error) {
+      captureException(error);
+    }
+    setInitLoadingFinish(true);
+    storage.set('isNotFirstLoading', true); // android 환경에서 알림 권한 거부한 유저에게 계속해서 권한요청을 하지 않게하는 flag
+
+    // alpha 환경인 경우 toast 알림
+    if (configData?.environment === 'alpha')
+      customShowToast('alphaEnvironmentInfo');
+
+    // codePush 업데이트 완료 후 재시작 하는경우, bootSplash screen을 보여주지 않습니다.
+    if (storage.getBoolean('isSuccessCodePushUpdate')) {
+      storage.set('isSuccessCodePushUpdate', false);
+      await handleFCMTokenBackground();
       return;
     }
-    checkForUpdateCodePush().finally(() => {
-      setIsServiceInitLoading(false);
-      storage.set('isNotFirstLoading', true);
-      if (configData?.environment === 'alpha')
-        customShowToast('alphaEnvironmentInfo');
-    });
-  }, [checkForUpdateCodePush, configData]);
 
-  const setAuthenticationSuccess = useCallback(async () => {
-    storage.set('isLoggedIn', true);
-    setLoadingFinish();
-  }, [setLoadingFinish]);
+    setSplashScreenVisible(true); // 로딩이 끝났을 경우, AnimatedBootSplashScreen을 보여줍니다.
+    await handleFCMTokenBackground();
+  };
 
-  // initialize App
-  const initApp = useCallback(async () => {
+  const initApp = async () => {
+    // supabase로부터 최신 버전 여부 확인
+    if (configData && !configData.isLatestVersion) {
+      guideUpdate(configData?.environment);
+      return;
+    }
+    // 알림 권한 요청
     await NotificationService.requestNotificationPermissions();
-    await NotificationService.handleFirebasePushToken();
 
-    const hasRefreshToken = UserService.getHasRefreshToken();
-    if (!hasRefreshToken) {
-      setLoadingFinish();
+    // refresh token이 없는 경우
+    if (!UserService.getHasRefreshToken()) {
+      handleLoadingFinish({isLogin: false});
       return;
     }
-
+    // 로그인 된 유저인지 검증
     try {
       await UserService.getAccessTokenByRefreshToken();
       const userInfo = await UserService.getUserInfoFromServer();
       setUserInfo(userInfo);
-    } catch (err) {
-      setLoadingFinish();
-      return;
-    }
-    try {
-      await DeviceService.updateDeviceInfo();
     } catch (error) {
+      // 에러 발생시 logging 후 logout처리
       captureException(error);
       await UserService.logoutByUnknownError();
-      setLoadingFinish();
+      handleLoadingFinish({isLogin: false});
       return;
     }
 
-    setAuthenticationSuccess();
-  }, [setAuthenticationSuccess, setLoadingFinish, setUserInfo]);
-
-  const isLoadingFinish = useMemo(
-    () => configData?.isLoading || isServiceInitLoading,
-    [configData?.isLoading, isServiceInitLoading],
-  );
+    handleLoadingFinish({isLogin: true});
+  };
 
   useEffect(() => {
-    if (!configData) return;
+    if (isInitLoadingFinish) return;
+    if (isFetching) return;
     initApp();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [configData]);
-
-  /** 로딩이 끝났을 경우, AnimatedBootSplashScreen을 보여줍니다.
-   * ```animatedBootSplashVisible: true```
-   * */
-  useEffect(() => {
-    if (isLoadingFinish) return;
-    setInitLoadingFinish(true);
-
-    // codePush 업데이트 완료 후 재시작 하는경우, bootSplash를 보여주지 않습니다.
-    if (storage.getBoolean('isSuccessCodePushUpdate')) {
-      storage.set('isSuccessCodePushUpdate', false);
-      return;
-    }
-
-    setAnimatedBootSplashVisible(true);
-    updateCodepush(codePushPackage);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isServiceInitLoading]);
-
-  /** 백그라운드에서 deepLink가 포함된 알림을 클릭하여 들어왔을 때 deeplink를 엽니다. */
-  useEffect(() => {
-    if (!isLoggedIn || isLoadingFinish) return;
-    (async () => {
-      const openedDeepLinkUrl = storage.getString('openedDeepLinkUrl');
-      if (openedDeepLinkUrl) {
-        await Linking.openURL(openedDeepLinkUrl);
-        storage.delete('openedDeepLinkUrl');
-      }
-    })();
-  }, [isLoadingFinish, isLoggedIn, isServiceInitLoading]);
-
-  return {
-    hasNetworkError: configData?.hasNetworkError,
-    isMaintenance,
-    isLoggedIn,
-    setIsLoggedIn,
-  };
+  }, [isFetching, isInitLoadingFinish]);
 };
 
 export default useInitApp;

--- a/src/hooks/useIsLoggedInListner.ts
+++ b/src/hooks/useIsLoggedInListner.ts
@@ -1,0 +1,14 @@
+import {useMMKVListener} from 'react-native-mmkv';
+import storage from '../storage';
+
+/** isLoggedIn value를 감시합니다. */
+const useIsLoggedInListner = (
+  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  useMMKVListener(changedKey => {
+    if (changedKey !== 'isLoggedIn') return;
+    setIsLoggedIn(storage.getBoolean(changedKey) ?? false);
+  }, storage);
+};
+
+export default useIsLoggedInListner;

--- a/src/hooks/useOpenDeeplink.ts
+++ b/src/hooks/useOpenDeeplink.ts
@@ -1,0 +1,21 @@
+/* eslint-disable import/prefer-default-export */
+import {useEffect} from 'react';
+import {Linking} from 'react-native';
+import {useAtomValue} from 'jotai';
+import storage from '../storage';
+import initLoadingFinishAtom from '../store/app/initLoading';
+
+/** 백그라운드에서 deepLink가 포함된 알림을 클릭하여 들어왔을 때 deeplink를 엽니다. */
+export const useOpenDeeplink = (isLoggedIn: boolean) => {
+  const isInitLoadingFinish = useAtomValue(initLoadingFinishAtom);
+  useEffect(() => {
+    if (!isLoggedIn || !isInitLoadingFinish) return;
+    (async () => {
+      const openedDeepLinkUrl = storage.getString('openedDeepLinkUrl');
+      if (openedDeepLinkUrl) {
+        await Linking.openURL(openedDeepLinkUrl);
+        storage.delete('openedDeepLinkUrl');
+      }
+    })();
+  }, [isInitLoadingFinish, isLoggedIn]);
+};

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -6,11 +6,9 @@ import customShowToast from '../configs/toast';
 import {DeleteUserInfoType, SetUserInfoType} from '../hooks/useUserState';
 import AnalyticsService from './analytics';
 import {AccountAPI} from '../api/services/account';
-import {UserInfoType} from '../api/services/account/type';
+import {JWTTokenType, UserInfoType} from '../api/services/account/type';
 
-type OnRegisterParamsType = {
-  accessToken: string;
-  refreshToken: string;
+type OnRegisterParamsType = JWTTokenType & {
   setUserInfo: SetUserInfoType;
   /** 바로 로그인하지 않을 때 사용하는 params입니다. */
   setNotLoggedIn?: true;

--- a/src/store/app/supabaseConfig.ts
+++ b/src/store/app/supabaseConfig.ts
@@ -6,12 +6,12 @@ import {ConfigAPI} from '../../api/services';
 export type AppEnvironment = 'production' | 'alpha';
 export type AppConfig = Map<string, string | string[]>;
 
-type SupabaseConfigAtomType = {
-  isLoading?: boolean;
+export type SupabaseConfigAtomType = {
   hasNetworkError: boolean;
   isLatestVersion?: boolean;
   config?: AppConfig;
   environment?: AppEnvironment;
+  isMaintenance?: boolean;
 };
 
 const changeAppVersionInt = (appVersion: string) =>
@@ -48,12 +48,15 @@ const supabaseConfigAtom = atomWithQuery<SupabaseConfigAtomType>(() => ({
         : changeAppVersionInt(
             configs.get('app.version.latest.android') as string,
           ) <= changeAppVersionInt(DeviceInfo.getVersion());
+
+    const isMaintenance = configs?.get('app.block') !== 'NO';
+
     return {
-      isLoading: false,
       hasNetworkError: false,
       config: configs,
       environment,
       isLatestVersion,
+      isMaintenance,
     };
   },
 }));

--- a/src/utils/app/guideUpdate.ts
+++ b/src/utils/app/guideUpdate.ts
@@ -1,0 +1,18 @@
+import {Alert} from 'react-native';
+import {UPDATE_GUIDE} from '../../configs/app/update_guide';
+import {AppEnvironment} from '../../store/app/supabaseConfig';
+import openAppstore from './openAppstore';
+
+/* eslint-disable import/prefer-default-export */
+export const guideUpdate = (environment: AppEnvironment | undefined) => {
+  if (environment === 'alpha') {
+    Alert.alert(UPDATE_GUIDE.ALPHA_TITLE, UPDATE_GUIDE.ALPHA_MESSAGE);
+    return;
+  }
+  Alert.alert(UPDATE_GUIDE.PROD_TITLE, UPDATE_GUIDE.PROD_MESSAGE, [
+    {
+      text: '이동하기',
+      onPress: openAppstore,
+    },
+  ]);
+};

--- a/src/utils/app/handleFCMTokenBackground.ts
+++ b/src/utils/app/handleFCMTokenBackground.ts
@@ -1,0 +1,17 @@
+import {captureException} from '@sentry/react-native';
+import DeviceService from '../../services/device';
+import NotificationService from '../../services/notification';
+import storage from '../../storage';
+
+/* eslint-disable import/prefer-default-export */
+export const handleFCMTokenBackground = async () => {
+  await NotificationService.handleFirebasePushToken();
+
+  if (!storage.getBoolean('isLoggedIn')) return;
+  // PATCH device info
+  try {
+    await DeviceService.updateDeviceInfo();
+  } catch (error) {
+    captureException(error);
+  }
+};

--- a/src/utils/storeToken.ts
+++ b/src/utils/storeToken.ts
@@ -1,11 +1,8 @@
-import {AuthTokenDefaultRes} from '../api/services/core/auth/authAPI.type';
+import {JWTTokenType} from '../api/services/account/type';
 import storage from '../storage';
 
-type StoreTokenType = Partial<AuthTokenDefaultRes>;
-
-const storeToken = ({accessToken, refreshToken, tempToken}: StoreTokenType) => {
+const storeToken = ({accessToken, refreshToken}: JWTTokenType) => {
   if (accessToken) storage.set('accessToken', accessToken);
   if (refreshToken) storage.set('refreshToken', refreshToken);
-  if (tempToken) storage.set('tempToken', tempToken);
 };
 export default storeToken;


### PR DESCRIPTION
# Key Changes

- 앱 초기 로딩시간을 개선하고, 리팩터링을 진행했습니다.
- supabase config를 가져오는 API를 AppState가 foreground일 때 refetch해오도록 구현했습니다.
- iOS 환경에서 UOSLIFE-Dev target의 bundle identifier를 `com.beyondconnect.uoslife`에서 `com.beyondconnect.uoslife.alpha`로 변경했습니다.

# Details

- 초기 로딩 시간에서 오래걸리는 FCM Token을 가져오는 동작을, 앱 로딩 완료 후 background에서 처리하도록 분리했습니다.
- useInitApp에서 사용하는 변수와 state를 적절히 추상화하여 동작에 따라 파일을 분리했습니다.
- supabase config에서 관리하는 점검 중 등의 상태를 초기 로딩에서만 가져와 점검 중일 때, 유저의 점검중 상태가 즉시 업데이트되지 않는 문제가 있었습니다.
- 이를 해결하기 위해 supabase config를 가져오는 API를 AppState가 foreground일 때 refetch해오도록 구현했습니다.

# Closes Issue

close #488 
