### PR TITLE
[RN-79] Device API 관련 동작 수정

### DIFF
--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -88,9 +88,6 @@ export default class NotificationService {
   }
 
   static async getFirebasePushToken(): Promise<string> {
-    if (Platform.OS === 'ios') {
-      messaging().setAPNSToken('app');
-    }
     const token = await this.getNotificationToken();
     return token;
   }

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -35,7 +35,7 @@ export default class UserService {
   }: OnRegisterParamsType): Promise<void> {
     storeToken({accessToken, refreshToken});
     await Promise.all([
-      DeviceService.setDeviceInfo(),
+      DeviceService.setDeviceInfoWhenAuthentication(),
       UserService.updateUserInfo(setUserInfo),
     ]);
     if (setNotLoggedIn) return;


### PR DESCRIPTION
# Key Changes

- DeviceService의 메서드들의 동작을 수정했습니다.
- iOS: fcm token을 가져오기 이전의 setAPNSToken 로직을 삭제했습니다.

# Details

- 기존: 로그인 또는 회원가입시 항상 device 정보를 새롭게 POST합니다.
- 변경: os와 model이 같다면 POST대신 가장 최신의 정보를 찾아 PATCH하도록 수정했습니다.
- refactor: local과 server의 device info를 비교하는 로직을 `synchronizeDeviceInfo()` 메서드로 분리했습니다.

# Closes Issue

close #490 
