### PR TITLE
[RN-83] Android 뒤로가기 동작 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,10 @@ import CustomNavigationContainer from './screens/CustomNavigationContainer';
 import bootSplashVisibleAtom from './store/app/bootSplashVisible';
 import {SENTRY_DEFAULT_SAMPLE_RATE} from './configs/sentry';
 
+// @ts-expect-error: platform specific file error (*TODO)
+// eslint-disable-next-line import/extensions
+import {useDoubleBackPress} from './hooks/useDoubleBackPress';
+
 Sentry.init({
   dsn: SENTRY_DSN_KEY,
   sampleRate: SENTRY_DEFAULT_SAMPLE_RATE,
@@ -32,6 +36,8 @@ let App: React.FC = () => {
     NotificationService.registerMessageHandler();
     NotificationService.onForegroundEvent();
   }, []);
+
+  useDoubleBackPress();
 
   return (
     <SafeAreaProvider>

--- a/src/hooks/useDoubleBackPress.android.ts
+++ b/src/hooks/useDoubleBackPress.android.ts
@@ -1,0 +1,35 @@
+import {useState, useCallback, useEffect} from 'react';
+import {ToastAndroid, BackHandler} from 'react-native';
+
+const TOAST_ANDROID_SHOW_SEC = 2.5 * 1000;
+
+export const useDoubleBackPress = () => {
+  const [backClickCount, setBackClickCount] = useState<number>(0);
+  const backAction = useCallback(() => {
+    setTimeout(() => {
+      setBackClickCount(0);
+    }, TOAST_ANDROID_SHOW_SEC);
+
+    if (backClickCount === 0) {
+      setBackClickCount(backClickCount + 1);
+
+      ToastAndroid.showWithGravity(
+        '한번 더 누르면 앱이 종료돼요.',
+        ToastAndroid.SHORT,
+        ToastAndroid.CENTER,
+      );
+    } else if (backClickCount === 1) {
+      BackHandler.exitApp();
+    }
+    return true;
+  }, [backClickCount]);
+
+  useEffect(() => {
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      backAction,
+    );
+
+    return () => backHandler.remove();
+  }, [backAction]);
+};

--- a/src/hooks/useDoubleBackPress.ios.ts
+++ b/src/hooks/useDoubleBackPress.ios.ts
@@ -1,0 +1,1 @@
+export const useDoubleBackPress = () => {};


### PR DESCRIPTION
# Key Changes

- Android에서 뒤로가기를 두번 클릭시 앱이 종료되도록 동작을 개선했습니다.

# Details

- iOS의 경우 빈 함수가 실행되도록 구현해, Android에서만 `useDoubleBackPress` 훅이 호출되도록 구현했습니다..
- `.android`, `.ios` 파일을 찾지 못하는 typescript 오류가 있어 해당 부분 우선적으로 `@ts-expect-error`를 사용하였고, 추후 수정이 필요합니다.

# Closes Issue

close #500 
