### PR TITLE
[tf-academic-calendar-38] 학사일정 페이지 추가

### DIFF
--- a/src/features/uos_lifestyle/academic_calendar/components/FilterButtonGroup.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/components/FilterButtonGroup.tsx
@@ -1,9 +1,7 @@
 import React, {useState} from 'react';
 import styled from '@emotion/native';
 import FilterButton from './FilterButton';
-import {ScheduleStatusType} from '../constants';
-
-const STATUSES = ['ALL', 'NOTIFICATION', 'IN_PROGRESS', 'ON_FILTER'] as const;
+import {STATUSES} from '../constants';
 
 const FilterButtonGroup = () => {
   const [selectedFilter, setSelectedFilter] = useState<string>('ALL');

--- a/src/features/uos_lifestyle/academic_calendar/constants.ts
+++ b/src/features/uos_lifestyle/academic_calendar/constants.ts
@@ -7,6 +7,14 @@ export type ScheduleStatusEnumType = Record<ScheduleStatusType, string>;
 
 export type ScheduleTabType = 'ALL' | 'MY_SCHEDULE';
 export type ScheduleTabEnumType = Record<ScheduleTabType, string>;
+
+export const STATUSES: ScheduleStatusType[] = [
+  'ALL',
+  'NOTIFICATION',
+  'IN_PROGRESS',
+  'ON_FILTER',
+] as const;
+
 export const ScheduleTabEnum: ScheduleTabEnumType = {
   ALL: '모든 일정',
   MY_SCHEDULE: '내 일정',

--- a/src/features/uos_lifestyle/academic_calendar/navigators/AcademicCalendarStackNavigator.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/navigators/AcademicCalendarStackNavigator.tsx
@@ -1,0 +1,26 @@
+import {createStackNavigator} from '@react-navigation/stack';
+
+import {AcademicCalendarStackParamList} from '../types/AcademicCalendar';
+import AcademicCalendarScreen from '../screens/AcademicCalendarScreen';
+import AcademicCalendarSearchScreen from '../screens/AcademicCalendarSearchScreen';
+
+const Stack = createStackNavigator<AcademicCalendarStackParamList>();
+
+const AcademicCalendarStackNavigator = () => {
+  return (
+    <Stack.Navigator
+      initialRouteName="academicCalendar"
+      screenOptions={{headerShown: false}}>
+      <Stack.Screen
+        name="academicCalendar"
+        component={AcademicCalendarScreen}
+      />
+      <Stack.Screen
+        name="academicCalendar_search"
+        component={AcademicCalendarSearchScreen}
+      />
+    </Stack.Navigator>
+  );
+};
+
+export default AcademicCalendarStackNavigator;

--- a/src/features/uos_lifestyle/academic_calendar/navigators/AcademicCalendarStackNavigator.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/navigators/AcademicCalendarStackNavigator.tsx
@@ -9,14 +9,14 @@ const Stack = createStackNavigator<AcademicCalendarStackParamList>();
 const AcademicCalendarStackNavigator = () => {
   return (
     <Stack.Navigator
-      initialRouteName="academicCalendar"
+      initialRouteName="academic_calendar"
       screenOptions={{headerShown: false}}>
       <Stack.Screen
-        name="academicCalendar"
+        name="academic_calendar"
         component={AcademicCalendarScreen}
       />
       <Stack.Screen
-        name="academicCalendar_search"
+        name="academic_calendar_search"
         component={AcademicCalendarSearchScreen}
       />
     </Stack.Navigator>

--- a/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarScreen.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarScreen.tsx
@@ -74,7 +74,7 @@ const AcademicCalendarScreen = () => {
           </S.TabWrapper>
 
           <S.IconWrapper
-            onPress={() => navigation.navigate('academicCalendar_search')}>
+            onPress={() => navigation.navigate('academic_calendar_search')}>
             <Icon name="search" width={24} height={24} />
           </S.IconWrapper>
         </S.TabContainer>

--- a/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarScreen.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarScreen.tsx
@@ -4,14 +4,13 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import styled from '@emotion/native';
 import {Icon, Txt, colors} from '@uoslife/design-system';
 import {useState} from 'react';
-import Header from '../../../../components/molecules/common/header/Header';
-import {RootNavigationProps} from '../../../../navigators/types/rootStack';
-import {ScheduleTabEnum} from '../constants';
 import {AcademicCalendarNavigationProp} from '../types/AcademicCalendar';
+import Header from '../../../../components/molecules/common/header/Header';
+import {ScheduleTabEnum} from '../constants';
 
 const AcademicCalendarScreen = () => {
   const inset = useSafeAreaInsets();
-  const navigation = useNavigation<RootNavigationProps>();
+  const navigation = useNavigation<AcademicCalendarNavigationProp>();
   const date = new Date();
   const week = ['일', '월', '화', '수', '목', '금', '토'];
   const [selectedTab, setSelectedTab] = useState(ScheduleTabEnum.ALL);
@@ -74,7 +73,8 @@ const AcademicCalendarScreen = () => {
             </S.TabButton>
           </S.TabWrapper>
 
-          <S.IconWrapper>
+          <S.IconWrapper
+            onPress={() => navigation.navigate('academicCalendar_search')}>
             <Icon name="search" width={24} height={24} />
           </S.IconWrapper>
         </S.TabContainer>
@@ -116,7 +116,7 @@ const S = {
     border-bottom-color: ${({isSelected}) =>
       isSelected ? colors.primaryBrand : 'transparent'};
   `,
-  IconWrapper: styled.View`
+  IconWrapper: styled.Pressable`
     padding: 12px;
   `,
 };

--- a/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarSearchScreen.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarSearchScreen.tsx
@@ -1,32 +1,50 @@
 import {useNavigation} from '@react-navigation/native';
 import {View} from 'react-native';
-import {useState} from 'react';
+import {useState, ComponentProps, useRef} from 'react';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {TextInput} from 'react-native-gesture-handler';
 import Header from '../../../../components/molecules/common/header/Header';
 import {RootNavigationProps} from '../../../../navigators/types/rootStack';
-import FilterButtonGroup from '../components/FilterButtonGroup';
+import SearchInput from '../../../../components/molecules/common/forms/searchInput/SearchInput';
 
 const AcademicCalendarSearchScreen = () => {
   const inset = useSafeAreaInsets();
   const navigation = useNavigation<RootNavigationProps>();
+  const [searchWord, setSearchWord] = useState<string>('');
+  const [isSearchWordEntering, setSearchWordEntering] =
+    useState<boolean>(false);
+  const inputRef = useRef<TextInput>(null);
+  const [dummy, setDummy] = useState<string>('');
 
-  // const currentDate: Date = new Date();
-  // const [month, setMonth] = useState<number>(currentDate.getMonth() + 1);
-  // const year: number = currentDate.getFullYear();
-  // const handlePreviousMonth = () => {
-  //   setMonth(month === 1 ? 12 : month - 1);
-  // };
-  // const handleNextMonth = () => {
-  //   setMonth(month === 12 ? 1 : month + 1);
-  // };
+  const searchInputProps: ComponentProps<typeof SearchInput> = {
+    inputRef,
+    placeholder: '일정을 검색하세요.',
+    onFocus: () => {
+      setSearchWordEntering(true);
+      inputRef.current?.focus();
+    },
+    onChangeText: text => {
+      setSearchWord(text);
+    },
+    onSubmitEditing: () => {
+      setDummy(searchWord);
+    },
+    onPressClear: () => {
+      setSearchWord('');
+      setSearchWordEntering(true);
+      inputRef.current?.focus();
+    },
+    value: searchWord,
+  };
 
   return (
     <View>
       <Header
         style={{paddingTop: inset.top, marginBottom: 8}}
-        label="학사일정검색"
-        onPressBackButton={() => navigation.goBack()}
-      />
+        label=""
+        onPressBackButton={() => navigation.goBack()}>
+        <SearchInput {...searchInputProps} />
+      </Header>
     </View>
   );
 };

--- a/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarSearchScreen.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarSearchScreen.tsx
@@ -2,16 +2,13 @@ import {useNavigation} from '@react-navigation/native';
 import {View} from 'react-native';
 import {useState} from 'react';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {Txt} from '@uoslife/design-system';
 import Header from '../../../../components/molecules/common/header/Header';
 import {RootNavigationProps} from '../../../../navigators/types/rootStack';
 import FilterButtonGroup from '../components/FilterButtonGroup';
-import {AcademicCalendarNavigationProp} from '../types/AcademicCalendar';
-import AnimatePress from '../../../../components/animations/pressable_icon/AnimatePress';
 
-const AcademicCalendarScreen = () => {
+const AcademicCalendarSearchScreen = () => {
   const inset = useSafeAreaInsets();
-  const navigation = useNavigation<AcademicCalendarNavigationProp>();
+  const navigation = useNavigation<RootNavigationProps>();
 
   // const currentDate: Date = new Date();
   // const [month, setMonth] = useState<number>(currentDate.getMonth() + 1);
@@ -27,16 +24,11 @@ const AcademicCalendarScreen = () => {
     <View>
       <Header
         style={{paddingTop: inset.top, marginBottom: 8}}
-        label="학사일정"
+        label="학사일정검색"
         onPressBackButton={() => navigation.goBack()}
       />
-      <AnimatePress
-        variant="scale_up_3"
-        onPress={() => navigation.navigate('academicCalendar_search')}>
-        <Txt label="asdasdasdasd" color="black" typograph="labelLarge" />
-      </AnimatePress>
     </View>
   );
 };
 
-export default AcademicCalendarScreen;
+export default AcademicCalendarSearchScreen;

--- a/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarSearchScreen.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/screens/AcademicCalendarSearchScreen.tsx
@@ -14,7 +14,7 @@ const AcademicCalendarSearchScreen = () => {
   const [isSearchWordEntering, setSearchWordEntering] =
     useState<boolean>(false);
   const inputRef = useRef<TextInput>(null);
-  const [dummy, setDummy] = useState<string>('');
+  const [dummy, setDummy] = useState<string>(''); // onSubmitEditing 동작용 더미 코드
 
   const searchInputProps: ComponentProps<typeof SearchInput> = {
     inputRef,

--- a/src/features/uos_lifestyle/academic_calendar/types/AcademicCalendar.ts
+++ b/src/features/uos_lifestyle/academic_calendar/types/AcademicCalendar.ts
@@ -1,8 +1,8 @@
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 
 export type AcademicCalendarStackParamList = {
-  academicCalendar?: undefined;
-  academicCalendar_search: undefined;
+  academic_calendar?: undefined;
+  academic_calendar_search: undefined;
 };
 
 // navigation props

--- a/src/features/uos_lifestyle/academic_calendar/types/AcademicCalendar.ts
+++ b/src/features/uos_lifestyle/academic_calendar/types/AcademicCalendar.ts
@@ -1,0 +1,10 @@
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+
+export type AcademicCalendarStackParamList = {
+  academicCalendar?: undefined;
+  academicCalendar_search: undefined;
+};
+
+// navigation props
+export type AcademicCalendarNavigationProp =
+  NativeStackNavigationProp<AcademicCalendarStackParamList>;

--- a/src/features/uos_lifestyle/academic_calendar/types/AcademicCalendar.ts
+++ b/src/features/uos_lifestyle/academic_calendar/types/AcademicCalendar.ts
@@ -1,7 +1,7 @@
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 
 export type AcademicCalendarStackParamList = {
-  academic_calendar?: undefined;
+  academic_calendar: undefined;
   academic_calendar_search: undefined;
 };
 

--- a/src/navigators/RootStackNavigator.tsx
+++ b/src/navigators/RootStackNavigator.tsx
@@ -25,7 +25,7 @@ import PortalAuthenticationScreen from '../features/account/components/screens/p
 import CheckGradeScreen from '../features/uos_lifestyle/check_grade/CheckGradeScreen';
 import LibraryRecapScreen from '../features/uos_lifestyle/library_recap/LibraryRecapScreen';
 import MeetingScreen from '../features/uos_lifestyle/meeting/MeetingScreen';
-import AcademicCalendarScreen from '../features/uos_lifestyle/academic_calendar/screens/AcademicCalendarScreen';
+import AcademicCalendarStackNavigator from '../features/uos_lifestyle/academic_calendar/navigators/AcademicCalendarStackNavigator';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -74,7 +74,7 @@ const RootStackNavigator: React.FC = () => {
           <Stack.Screen name="check_grade" component={CheckGradeScreen} />
           <Stack.Screen
             name="academic_calendar"
-            component={AcademicCalendarScreen}
+            component={AcademicCalendarStackNavigator}
           />
         </Stack.Group>
       ) : (


### PR DESCRIPTION
# Key Changes

- 학사일정 검색 페이지 추가
- 스택 네비게이션 설정(navigator 폴더 및 파일 추가)
- 학사일정 스크린에서 돋보기 클릭시 학사일정 검색 스크린으로 네비게이션
- 학사일정 검색 스크린에서 SearchInput컴포넌트 적용

- 필터 구분하는 상수 추가

+++++
- Camel case와 Snake case 혼종되어있는 것 수정

# Details

- 검색시 동작은 현재까지 미구현


# To Reviewers

- 

# Closes Issue

close #ISSUE
