### PR TITLE
[tf-academic-calendar-53] 알림설정 활성화시간 수정

### DIFF
--- a/src/features/uos_lifestyle/academic_calendar/components/ScheduleItem.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/components/ScheduleItem.tsx
@@ -66,12 +66,22 @@ const ScheduleItem = ({
     const standardDateStr = schedule.startDate;
     const formattedStandardDateStr = standardDateStr.split('.').join('-');
     const standardDate = new Date(formattedStandardDateStr); // KST
+    const scheduleReflectTime =
+      standardDate.getTime() -
+      standardDate.getTimezoneOffset() * 60 * 1000 +
+      9 * 60 * 60 * 1000;
     const today = new Date();
-    const result = today.getTime() - standardDate.getTime();
+    const utcToday = today.getTime() - today.getTimezoneOffset() * 60 * 1000;
+    // UTC 기준으로 설정된 시간을 확인
+    const utcDate = new Date(utcToday);
+    const scDate = new Date(scheduleReflectTime);
+    const result = scDate.getTime() - utcDate.getTime();
     const flag = result / 1000 / 60 / 60;
-    if (flag >= 0) setIsNotiInactive(true);
+    if (flag <= 9) setIsNotiInactive(true);
     else setIsNotiInactive(false);
   }, [schedule, tabType]);
+
+  // 타임존에서 31시간 지나면,
 
   useEffect(() => {});
 
@@ -175,15 +185,24 @@ const ScheduleItem = ({
                     if (!notificationHandler) return;
                     if (schedule.setNotification === undefined) return;
 
-                    const standardDateStr = schedule.endDate;
+                    const standardDateStr = schedule.startDate;
                     const formattedStandardDateStr = standardDateStr
                       .split('.')
                       .join('-');
                     const standardDate = new Date(formattedStandardDateStr); // KST
+                    const scheduleReflectTime =
+                      standardDate.getTime() -
+                      standardDate.getTimezoneOffset() * 60 * 1000 +
+                      9 * 60 * 60 * 1000;
                     const today = new Date();
-                    const result = today.getTime() - standardDate.getTime();
+                    const utcToday =
+                      today.getTime() - today.getTimezoneOffset() * 60 * 1000;
+
+                    const utcDate = new Date(utcToday);
+                    const scDate = new Date(scheduleReflectTime);
+                    const result = scDate.getTime() - utcDate.getTime();
                     const flag = result / 1000 / 60 / 60;
-                    if (flag >= 24) return;
+                    if (flag <= 9) return;
                     setIsNotificated(!isNotificated);
                     notificationHandler(
                       schedule.scheduleId,

--- a/src/features/uos_lifestyle/academic_calendar/components/ScheduleItem.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/components/ScheduleItem.tsx
@@ -63,13 +63,13 @@ const ScheduleItem = ({
       if (schedule.setNotification === undefined) return;
       setIsNotificated(schedule.setNotification);
     }
-    const standardDateStr = schedule.endDate;
+    const standardDateStr = schedule.startDate;
     const formattedStandardDateStr = standardDateStr.split('.').join('-');
     const standardDate = new Date(formattedStandardDateStr); // KST
     const today = new Date();
     const result = today.getTime() - standardDate.getTime();
     const flag = result / 1000 / 60 / 60;
-    if (flag >= 24) setIsNotiInactive(true);
+    if (flag >= 0) setIsNotiInactive(true);
     else setIsNotiInactive(false);
   }, [schedule, tabType]);
 

--- a/src/features/uos_lifestyle/academic_calendar/components/ScheduleItem.tsx
+++ b/src/features/uos_lifestyle/academic_calendar/components/ScheduleItem.tsx
@@ -81,10 +81,6 @@ const ScheduleItem = ({
     else setIsNotiInactive(false);
   }, [schedule, tabType]);
 
-  // 타임존에서 31시간 지나면,
-
-  useEffect(() => {});
-
   useEffect(() => {
     if (isChecked) return;
     setChecked(isChecked);


### PR DESCRIPTION
# Key Changes

- 알림설정 활성화시간 시작일 09시 이전으로 수정

# Details

- today : UTC기준 현재시간
- standardDate : 일정 시작일 00시
- 한국 기준으로 해서 시차(9시간)와 일정시작시간(오전9시) 고려해서 flag>0이면 비활성화 
->사용자의 location에 따라 동적으로 시간 계산하여 활성화 여부 결정하도록 수정


# Closes Issue

close #ISSUE
