### PR TITLE
[RN-111] API 응답시 처리 수정

### DIFF
--- a/src/api/core/customError.ts
+++ b/src/api/core/customError.ts
@@ -1,0 +1,25 @@
+import {IErrorResponse, ErrorCode} from '../services/type';
+
+export class CustomError extends Error implements IErrorResponse {
+  code: ErrorCode;
+
+  date: Date;
+
+  status: number;
+
+  // @ts-expect-error: expected params
+  constructor(status: number, code: ErrorCode, ...params) {
+    // Pass remaining arguments (including vendor specific ones) to parent constructor
+    super(...params);
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CustomError);
+    }
+
+    // Custom debugging information
+    this.code = code;
+    this.date = new Date();
+    this.status = status;
+  }
+}

--- a/src/api/services/type.ts
+++ b/src/api/services/type.ts
@@ -1,10 +1,12 @@
-export type KyJsonResponse<T> = Promise<T>;
+export type KyJsonResponse<T> = Promise<string | Awaited<T>>;
 
 export type ServiceFunc<Params = unknown | undefined, Res = unknown> = (
   params: Params,
 ) => KyJsonResponse<Res>;
 
 export type ServiceFuncWithoutParams<Res = unknown> = () => KyJsonResponse<Res>;
+
+export type ClientType = 'DEFAULT' | 'ACCOUNT';
 
 export interface IErrorResponse extends Error {
   code: ErrorCode;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,16 @@
+import {apiClient, accountApiClient} from '../api/core/client';
+import {ClientType} from '../api/services/type';
+
+// eslint-disable-next-line consistent-return
+export const changeClient = (client: ClientType) => {
+  switch (client) {
+    case 'DEFAULT':
+      return apiClient;
+    case 'ACCOUNT':
+      return accountApiClient;
+  }
+};
+
+export const isJsonContentType = (contentType: ReturnType<Headers['get']>) => {
+  return contentType && contentType.includes('application/json');
+};


### PR DESCRIPTION
# Key Changes

- API 응답값이 json이 아닌 경우 발생하는 오류(**iOS 앱의 process가 종료되는 현상**)를 해결했습니다.

# Details

- 서버에서 오는 응답의 `Content-Type`이 `application/json`이 아닌 경우 response.json()대신 .text() 함수를 호출하도록 수정했습니다.
- method.ts 파일 내에 작성되었던 CustomError 객체와, util 함수, type 선언 등을 각 파일로 분리했습니다.

# Closes Issue

close #587 
