### PR TITLE
[RN-113] 서버 api url 환경을 개발 환경에서 선택할 수 있도록 변경

### DIFF
--- a/src/configs/api.ts
+++ b/src/configs/api.ts
@@ -1,11 +1,16 @@
+/** you can change alpha / prod api server prefix */
+const ENABLE_ALPHA_API_SERVER = true;
+
+const getApiServerPrefix = () => {
+  return ENABLE_ALPHA_API_SERVER ? 'alpha.' : '';
+};
+
 const 초 = 1000;
 
 export const DEFAULT_API_TIMEOUT = 3 * 초;
 export const DEFAULT_API_RETRY_LIMIT = 4;
 export const DEFAULT_API_RETRY_BACKOFFLIMIT = 0.5 * 초;
 
-export const BASE_API_URL = `https://api.${__DEV__ ? 'alpha.' : ''}uoslife.com`;
-export const ACCOUNT_API_URL = `https://account.${
-  __DEV__ ? 'alpha.' : ''
-}uoslife.com`;
+export const BASE_API_URL = `https://api.${getApiServerPrefix()}uoslife.com`;
+export const ACCOUNT_API_URL = `https://account.${getApiServerPrefix()}uoslife.com`;
 export const CDN_API_URL = 'https://cdn.uoslife.net';


### PR DESCRIPTION
# Key Changes

- 서버 api url 환경을 개발 환경에서 선택할 수 있도록 변경했습니다.

# Details

- 기존 사용하던 `__DEV__` 변수대신, `src/configs/api.ts`파일의 `ENABLE_ALPHA_API_SERVER` 변수를 이용해 api url 환경을 선택할 수 있도록 수정했습니다.

# Closes Issue

close #589 
